### PR TITLE
ci: migrate macOS runners and bound queue starvation

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -34,6 +34,7 @@ on:
 # main are never cancelled: release-auto.yml triggers on push-to-main
 # version bumps, so every commit that lands must be fully tested.
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -43,13 +44,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  # macos-14 is Apple Silicon. This was previously two jobs, `x86` and `arm`,
-  # both pinned to macos-14 — byte-identical duplicates that also derived the
+  # macos-15 is Apple Silicon. This was previously two jobs, `x86` and `arm`,
+  # both pinned to the same arm64 image, byte-identical duplicates that also derived the
   # same cache-key-suffix and so raced each other on cache save. Real Intel
   # coverage would mean macos-13, which is deliberately avoided: see
   # wrapper-e2e.yml, where that pool cost 15+ minutes of queue wait per run.
   macos:
     uses: ./.github/workflows/ci-check.yml
     with:
-      os: macos-14
+      os: macos-15
       run_check: false
+
+  observe-macos-queue:
+    name: Observe macOS runner queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - name: Bound macOS queue starvation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          uv run --no-project --python 3.13 python ci/observe_runner_queue.py
+          --repository "${{ github.repository }}" --run-id "${{ github.run_id }}"
+          --runner macos-15 --job "macos / Test" --token "$GITHUB_TOKEN"

--- a/.github/workflows/fs-matrix.yml
+++ b/.github/workflows/fs-matrix.yml
@@ -32,6 +32,7 @@ on:
       - "tasks/**"
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -45,7 +46,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-14]
+        os: [windows-latest, ubuntu-latest, macos-15]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v6
@@ -96,6 +97,21 @@ jobs:
         run: >-
           soldr cargo test -p zccache-daemon-core --features test-support
           refs_non_cluster_multiple_round_trips -- --nocapture --test-threads=1
+
+  observe-macos-queue:
+    name: Observe macOS runner queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - name: Bound macOS queue starvation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          uv run --no-project --python 3.13 python ci/observe_runner_queue.py
+          --repository "${{ github.repository }}" --run-id "${{ github.run_id }}"
+          --runner macos-15 --job "matrix (macos-15)" --token "$GITHUB_TOKEN"
 
   large-cow:
     if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'

--- a/.github/workflows/release-auto.yml
+++ b/.github/workflows/release-auto.yml
@@ -20,6 +20,7 @@ on:
         type: boolean
 
 permissions:
+  actions: read
   contents: write
 
 env:
@@ -520,7 +521,7 @@ jobs:
             wheel_plat: manylinux_2_17_x86_64
           - os: ubuntu-24.04-arm
             wheel_plat: manylinux_2_17_aarch64
-          - os: macos-14
+          - os: macos-15
             wheel_plat: macosx_11_0_arm64
           - os: windows-latest
             wheel_plat: win_amd64
@@ -553,7 +554,7 @@ jobs:
   # neutralizes a job that RUNS and FAILS; the observed failure is a job that
   # never starts. A queued job has no result, so `needs: test-wheels` simply
   # waits -- for the 24h queue limit, not for the fix. During 1.13.14 the
-  # `macos-14` arm64 leg finished in minutes while `macos-15-intel` never
+  # The supported macos-15 arm64 leg finished in minutes while the former Intel pool never
   # picked up a host, twice, and the crates.io publish sat behind it both
   # times. A gate that cannot run is not a gate, and the only way to stop it
   # gating is to take it out of the dependency edge.
@@ -574,7 +575,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-15-intel
+          - os: macos-15
             wheel_plat: macosx_10_12_x86_64
     steps:
       - uses: actions/checkout@v6
@@ -584,6 +585,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
+          architecture: x64
+
+      - name: Require Rosetta for Intel wheel smoke
+        shell: bash
+        run: arch -x86_64 /usr/bin/true
 
       - uses: actions/download-artifact@v8
         with:
@@ -592,8 +598,26 @@ jobs:
 
       - name: Install and test the platform wheel
         run: |
-          python -m pip install --disable-pip-version-check --no-index --find-links dist/wheels "zccache==${{ needs.preflight.outputs.version }}"
-          python ci/test_exec_cached_wheel.py
+          arch -x86_64 python -m pip install --disable-pip-version-check --no-index --find-links dist/wheels "zccache==${{ needs.preflight.outputs.version }}"
+          arch -x86_64 python ci/test_exec_cached_wheel.py
+
+  observe-macos-queue:
+    name: Observe macOS runner queue
+    runs-on: ubuntu-latest
+    needs: [preflight, build-wheels]
+    if: needs.preflight.outputs.pypi_complete != 'true'
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - name: Bound macOS queue starvation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          uv run --no-project --python 3.13 python ci/observe_runner_queue.py
+          --repository "${{ github.repository }}" --run-id "${{ github.run_id }}"
+          --runner macos-15 --job "Test PyPI Wheel (macosx_11_0_arm64)"
+          --job "Test PyPI Wheel (macosx_10_12_x86_64)" --token "$GITHUB_TOKEN"
 
   publish-pypi:
     name: Publish PyPI

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -19,6 +19,7 @@ on:
   workflow_dispatch:
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -53,7 +54,7 @@ jobs:
             os: macos-15
             target: aarch64-apple-darwin
           - name: macOS x86_64
-            os: macos-14
+            os: macos-15
             target: x86_64-apple-darwin
           - name: Windows x86_64
             os: windows-2025
@@ -174,6 +175,22 @@ jobs:
         uses: ./action/cleanup
 
   # Test that save-cache: false works (for PR builds)
+  observe-macos-queue:
+    name: Observe macOS runner queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - name: Bound macOS queue starvation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          uv run --no-project --python 3.13 python ci/observe_runner_queue.py
+          --repository "${{ github.repository }}" --run-id "${{ github.run_id }}"
+          --runner macos-15 --job "macOS ARM" --job "macOS x86_64"
+          --token "$GITHUB_TOKEN"
+
   test-no-save:
     name: "No-save mode (Linux)"
     runs-on: ubuntu-24.04

--- a/.github/workflows/wrapper-e2e.yml
+++ b/.github/workflows/wrapper-e2e.yml
@@ -5,7 +5,7 @@ name: Wrapper end-to-end
 # small crate with proc-macro build scripts (serde --features derive),
 # routing every rustc invocation through the freshly-built wrapper.
 #
-# Green on macos-13 / macos-14 is the acceptance signal that the 1.7.2
+# Green on the supported Apple Silicon runner is the acceptance signal that the 1.7.2
 # macOS regression — build-script rustc failing in ~4ms with stderr
 # swallowed — is fixed.
 
@@ -38,6 +38,7 @@ on:
       - "tasks/**"
 
 permissions:
+  actions: read
   contents: read
 
 concurrency:
@@ -52,13 +53,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # macos-14 (arm64) is the active macOS leg. It already validates
+          # macos-15 (arm64) is the active macOS leg. It already validates
           # the 1.7.2 regression fix end-to-end and runs on the modern
           # Apple Silicon image where the Intel-only `macos-13` runner
           # pool is consistently scarce — keeping macos-13 in the matrix
           # added 15+ minutes of queue wait per run for redundant coverage.
           # Re-add if a future regression turns out to be Intel-specific.
-          - os: macos-14       # Apple Silicon — primary macOS coverage
+          - os: macos-15       # Apple Silicon — primary macOS coverage
           - os: ubuntu-latest  # parity reference
           - os: windows-latest # parity reference
     runs-on: ${{ matrix.os }}
@@ -329,3 +330,18 @@ jobs:
               Get-Content $_.FullName -ErrorAction SilentlyContinue
             }
           }
+
+  observe-macos-queue:
+    name: Observe macOS runner queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - name: Bound macOS queue starvation
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: >-
+          uv run --no-project --python 3.13 python ci/observe_runner_queue.py
+          --repository "${{ github.repository }}" --run-id "${{ github.run_id }}"
+          --runner macos-15 --job "wrapper-e2e (macos-15)" --token "$GITHUB_TOKEN"

--- a/README.md
+++ b/README.md
@@ -946,7 +946,7 @@ jobs:
           - { os: ubuntu-24.04,     target: x86_64-unknown-linux-gnu }
           - { os: ubuntu-24.04-arm, target: aarch64-unknown-linux-gnu }
           - { os: macos-15,         target: aarch64-apple-darwin }
-          - { os: macos-14,         target: x86_64-apple-darwin }
+          - { os: macos-15,         target: x86_64-apple-darwin }
           - { os: windows-2025,     target: x86_64-pc-windows-msvc }
     runs-on: ${{ matrix.os }}
     steps:

--- a/ci/observe_runner_queue.py
+++ b/ci/observe_runner_queue.py
@@ -1,0 +1,238 @@
+"""Bound queue starvation for GitHub-hosted runner jobs.
+
+Workflow YAML supplies only a repository, run id, runner label, and expected
+job names.  This helper owns GitHub API parsing, queue-age accounting, bounded
+polling, and the durable step-summary diagnostic required by zccache#1541.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from enum import Enum
+from pathlib import Path
+from typing import Protocol
+
+
+class GitHubApiError(RuntimeError):
+    """The Actions API could not provide a state that CI can diagnose."""
+
+
+class QueueState(Enum):
+    MISSING = "missing"
+    QUEUED = "queued"
+    STARTED = "started"
+    COMPLETED = "completed"
+
+
+@dataclass(frozen=True)
+class QueueObservation:
+    """One expected job's observable scheduling state."""
+
+    job_name: str
+    configured_runner: str
+    runner_labels: tuple[str, ...]
+    state: QueueState
+    status: str
+    conclusion: str | None
+    queue_age: timedelta | None
+
+
+class JsonApi(Protocol):
+    def get_json(self, path: str) -> object: ...
+
+
+def _parse_timestamp(value: object, field: str) -> datetime:
+    if not isinstance(value, str):
+        raise GitHubApiError(f"GitHub Actions response has no string {field}")
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+    except ValueError as error:
+        raise GitHubApiError(f"GitHub Actions response has invalid {field}={value!r}") from error
+
+
+def _mapping(value: object, context: str) -> Mapping[str, object]:
+    if not isinstance(value, Mapping):
+        raise GitHubApiError(f"GitHub Actions response has non-object {context}")
+    return value
+
+
+class GitHubApi:
+    """Small, dependency-free GitHub REST client for workflow queue state."""
+
+    def __init__(self, token: str) -> None:
+        self._token = token
+
+    def get_json(self, path: str) -> object:
+        request = urllib.request.Request(
+            f"https://api.github.com{path}",
+            headers={
+                "Accept": "application/vnd.github+json",
+                "Authorization": f"Bearer {self._token}",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=20) as response:
+                return json.load(response)
+        except (urllib.error.HTTPError, urllib.error.URLError, TimeoutError, json.JSONDecodeError) as error:
+            raise GitHubApiError(f"GitHub Actions API request {path} failed: {error}") from error
+
+
+def fetch_workflow_state(api: JsonApi, repository: str, run_id: int) -> tuple[Mapping[str, object], list[Mapping[str, object]]]:
+    """Fetch the run and its complete job list, refusing partial API output."""
+    run = _mapping(api.get_json(f"/repos/{repository}/actions/runs/{run_id}"), "run")
+    jobs: list[Mapping[str, object]] = []
+    page = 1
+    while True:
+        payload = _mapping(
+            api.get_json(f"/repos/{repository}/actions/runs/{run_id}/jobs?per_page=100&page={page}"),
+            f"jobs page {page}",
+        )
+        raw_jobs = payload.get("jobs")
+        total_count = payload.get("total_count")
+        if not isinstance(raw_jobs, list) or not all(isinstance(job, Mapping) for job in raw_jobs) or not isinstance(total_count, int):
+            raise GitHubApiError(f"GitHub Actions response has invalid jobs page {page}")
+        jobs.extend(raw_jobs)
+        if len(jobs) >= total_count:
+            return run, jobs
+        if not raw_jobs:
+            raise GitHubApiError(f"GitHub Actions jobs pagination ended at {len(jobs)} of declared {total_count} jobs")
+        page += 1
+
+
+def observe_once(
+    run: Mapping[str, object],
+    jobs: Sequence[Mapping[str, object]],
+    expected_jobs: Sequence[str],
+    *,
+    now: datetime,
+    configured_runner: str,
+) -> list[QueueObservation]:
+    """Classify expected job names without relying on mutable presentation text."""
+    jobs_by_name = {name: job for job in jobs if isinstance((name := job.get("name")), str)}
+    observations: list[QueueObservation] = []
+    for name in expected_jobs:
+        job = jobs_by_name.get(name)
+        if job is None:
+            observations.append(
+                QueueObservation(
+                    name,
+                    configured_runner,
+                    (),
+                    QueueState.MISSING,
+                    "missing",
+                    None,
+                    None,
+                )
+            )
+            continue
+
+        created = _parse_timestamp(job.get("created_at"), f"job {name!r}.created_at")
+        started_at = job.get("started_at")
+        completed_at = job.get("completed_at")
+        labels = job.get("labels")
+        runner_labels = tuple(label for label in labels if isinstance(label, str)) if isinstance(labels, list) else ()
+        status = str(job.get("status", "unknown"))
+        conclusion = job.get("conclusion") if isinstance(job.get("conclusion"), str) else None
+        if completed_at is not None:
+            state = QueueState.COMPLETED
+            queue_end = _parse_timestamp(started_at, f"job {name!r}.started_at") if started_at is not None else now
+        elif started_at is not None:
+            state = QueueState.STARTED
+            queue_end = _parse_timestamp(started_at, f"job {name!r}.started_at")
+        else:
+            state = QueueState.QUEUED
+            queue_end = now
+        observations.append(QueueObservation(name, configured_runner, runner_labels, state, status, conclusion, queue_end - created))
+    return observations
+
+
+def queue_violations(observations: Sequence[QueueObservation], maximum: timedelta, *, missing_visible: bool = True) -> list[QueueObservation]:
+    """Return only jobs that are still absent/queued beyond the hard bound."""
+    return [
+        observation
+        for observation in observations
+        if (observation.state is QueueState.QUEUED and observation.queue_age is not None and observation.queue_age >= maximum) or (observation.state is QueueState.MISSING and missing_visible)
+    ]
+
+
+def render_summary(observations: Sequence[QueueObservation], *, repository: str | None = None, run_id: int | None = None) -> str:
+    """Render a compact diagnostic suitable for both logs and step summaries."""
+    lines = ["### Hosted runner queue observer", "", "| job | runner | state | queued age | labels |", "| --- | --- | --- | --- | --- |"]
+    if repository is not None and run_id is not None:
+        lines[2:2] = [f"Workflow: `{repository}` run `{run_id}`", ""]
+    for observation in observations:
+        labels = ", ".join(observation.runner_labels) or "(not assigned)"
+        age = f"{int(observation.queue_age.total_seconds())}s" if observation.queue_age is not None else "not visible"
+        lines.append(f"| `{observation.job_name}` | `{observation.configured_runner}` | `{observation.state.value}` | {age} | {labels} |")
+    return "\n".join(lines) + "\n"
+
+
+def _append_summary(text: str) -> None:
+    summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary:
+        with Path(summary).open("a", encoding="utf-8") as handle:
+            handle.write(text)
+
+
+def _positive_seconds(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("must be positive")
+    return parsed
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--run-id", required=True, type=int)
+    parser.add_argument("--job", action="append", required=True, dest="jobs")
+    parser.add_argument("--runner", required=True)
+    parser.add_argument("--token", required=True)
+    parser.add_argument("--max-queue-seconds", type=_positive_seconds, default=900)
+    parser.add_argument("--identity-visibility-grace-seconds", type=_positive_seconds, default=120)
+    parser.add_argument("--poll-seconds", type=_positive_seconds, default=30)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _arguments()
+    api = GitHubApi(args.token)
+    maximum = timedelta(seconds=args.max_queue_seconds)
+    visibility_deadline = time.monotonic() + args.identity_visibility_grace_seconds
+    while True:
+        try:
+            run, jobs = fetch_workflow_state(api, args.repository, args.run_id)
+            observations = observe_once(run, jobs, args.jobs, now=datetime.now(UTC), configured_runner=args.runner)
+        except GitHubApiError as error:
+            diagnostic = f"### Hosted runner queue observer\n\nAPI error: `{error}`\n"
+            print(diagnostic, file=sys.stderr)
+            _append_summary(diagnostic)
+            return 1
+
+        summary = render_summary(observations, repository=args.repository, run_id=args.run_id)
+        print(summary)
+        _append_summary(summary)
+        violations = queue_violations(observations, maximum, missing_visible=time.monotonic() >= visibility_deadline)
+        if violations:
+            print(
+                "Hosted runner queue bound exceeded for: " + ", ".join(observation.job_name for observation in violations),
+                file=sys.stderr,
+            )
+            return 1
+        if all(observation.state in {QueueState.STARTED, QueueState.COMPLETED} for observation in observations):
+            return 0
+        time.sleep(args.poll_seconds)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ci/tests/test_macos_runner_migration.py
+++ b/ci/tests/test_macos_runner_migration.py
@@ -1,0 +1,64 @@
+"""Static CI contract for the macOS 14 retirement and queue observer (#1541)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+MACOS_WORKFLOWS = {
+    "ci-macos.yml": ["macos / Test"],
+    "fs-matrix.yml": ["matrix (macos-15)"],
+    "wrapper-e2e.yml": ["wrapper-e2e (macos-15)"],
+    "test-action.yml": ["macOS ARM", "macOS x86_64"],
+    "release-auto.yml": [
+        "Test PyPI Wheel (macosx_11_0_arm64)",
+        "Test PyPI Wheel (macosx_10_12_x86_64)",
+    ],
+}
+
+
+def _workflow(name: str) -> str:
+    return (WORKFLOWS / name).read_text(encoding="utf-8")
+
+
+def _job(text: str, name: str) -> str:
+    marker = f"  {name}:\n"
+    start = text.index(marker)
+    following = re.search(r"^  [a-z][a-z0-9-]*:\n", text[start + len(marker) :], re.MULTILINE)
+    end = start + len(marker) + following.start() if following else len(text)
+    return text[start:end]
+
+
+def test_all_load_bearing_macos_lanes_use_the_supported_arm_runner_and_observer() -> None:
+    """No direct macOS 14 consumer may return without a bounded observer."""
+    for workflow_name, expected_jobs in MACOS_WORKFLOWS.items():
+        workflow = _workflow(workflow_name)
+        assert "macos-14" not in workflow, workflow_name
+        assert "permissions:" in workflow and "actions: read" in workflow, workflow_name
+        observer = _job(workflow, "observe-macos-queue")
+        assert "astral-sh/setup-uv@v6" in observer, workflow_name
+        assert "uv run --no-project --python 3.13 python ci/observe_runner_queue.py" in observer, workflow_name
+        assert "--runner macos-15" in observer, workflow_name
+        for job in expected_jobs:
+            assert f'--job "{job}"' in observer, (workflow_name, job)
+
+
+def test_intel_wheel_is_smoked_under_a_loud_rosetta_boundary() -> None:
+    """Intel support remains real execution, never a silent ARM substitution."""
+    workflow = _workflow("release-auto.yml")
+    ungated = _job(workflow, "test-wheels-ungated")
+    assert "- os: macos-15" in ungated
+    assert "architecture: x64" in ungated
+    assert "arch -x86_64 /usr/bin/true" in ungated
+    assert "arch -x86_64 python -m pip install" in ungated
+    assert "arch -x86_64 python ci/test_exec_cached_wheel.py" in ungated
+
+
+def test_intel_wheel_smoke_remains_outside_every_publish_needs_edge() -> None:
+    """#1538's release-dependency repair must survive the migration."""
+    workflow = _workflow("release-auto.yml")
+    publish_jobs = ("publish-pypi", "publish-crates")
+    for job in publish_jobs:
+        assert "test-wheels-ungated" not in _job(workflow, job)

--- a/ci/tests/test_observe_runner_queue.py
+++ b/ci/tests/test_observe_runner_queue.py
@@ -1,0 +1,152 @@
+"""Regression coverage for bounded hosted-runner queue diagnostics (#1541)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from ci import observe_runner_queue
+
+NOW = datetime(2026, 8, 28, 6, 0, tzinfo=UTC)
+RUN = {"created_at": "2026-08-28T05:30:00Z"}
+
+
+def _job(**overrides: object) -> dict[str, object]:
+    job: dict[str, object] = {
+        "name": "matrix (macos-15)",
+        "status": "queued",
+        "conclusion": None,
+        "created_at": "2026-08-28T05:30:00Z",
+        "started_at": None,
+        "completed_at": None,
+        "labels": ["macos-15"],
+    }
+    job.update(overrides)
+    return job
+
+
+def test_queued_job_reports_age_and_crosses_the_bound() -> None:
+    observation = observe_runner_queue.observe_once(
+        RUN,
+        [_job()],
+        ["matrix (macos-15)"],
+        now=NOW,
+        configured_runner="macos-15",
+    )[0]
+
+    assert observation.state is observe_runner_queue.QueueState.QUEUED
+    assert observation.queue_age == timedelta(minutes=30)
+    assert observe_runner_queue.queue_violations([observation], timedelta(minutes=15)) == [observation]
+    summary = observe_runner_queue.render_summary([observation], repository="zackees/zccache", run_id=123)
+    assert "Workflow: `zackees/zccache` run `123`" in summary
+    assert "| `matrix (macos-15)` | `macos-15` | `queued` |" in summary
+
+
+def test_started_and_completed_jobs_are_not_queue_failures() -> None:
+    observations = observe_runner_queue.observe_once(
+        RUN,
+        [
+            _job(status="in_progress", started_at="2026-08-28T05:35:00Z"),
+            _job(
+                name="Test PyPI Wheel (macosx_10_12_x86_64)",
+                status="completed",
+                conclusion="success",
+                started_at="2026-08-28T05:34:00Z",
+                completed_at="2026-08-28T05:40:00Z",
+            ),
+        ],
+        ["matrix (macos-15)", "Test PyPI Wheel (macosx_10_12_x86_64)"],
+        now=NOW,
+        configured_runner="macos-15",
+    )
+
+    assert [entry.state for entry in observations] == [
+        observe_runner_queue.QueueState.STARTED,
+        observe_runner_queue.QueueState.COMPLETED,
+    ]
+    assert observe_runner_queue.queue_violations(observations, timedelta(seconds=1)) == []
+
+
+def test_immediate_start_is_reported_as_zero_queue_seconds() -> None:
+    observation = observe_runner_queue.observe_once(
+        RUN,
+        [_job(status="in_progress", started_at="2026-08-28T05:30:00Z")],
+        ["matrix (macos-15)"],
+        now=NOW,
+        configured_runner="macos-15",
+    )[0]
+
+    assert "| `matrix (macos-15)` | `macos-15` | `started` | 0s |" in observe_runner_queue.render_summary([observation])
+
+
+def test_missing_job_uses_workflow_queue_age() -> None:
+    observation = observe_runner_queue.observe_once(
+        RUN,
+        [],
+        ["wrapper-e2e (macos-15)"],
+        now=NOW,
+        configured_runner="macos-15",
+    )[0]
+
+    assert observation.state is observe_runner_queue.QueueState.MISSING
+    assert observation.queue_age is None
+    assert observe_runner_queue.queue_violations([observation], timedelta(seconds=1), missing_visible=False) == []
+    assert observe_runner_queue.queue_violations([observation], timedelta(seconds=1), missing_visible=True) == [observation]
+
+
+def test_late_job_visibility_uses_the_target_job_created_at_not_old_run_age() -> None:
+    missing = observe_runner_queue.observe_once(
+        RUN,
+        [],
+        ["wrapper-e2e (macos-15)"],
+        now=NOW,
+        configured_runner="macos-15",
+    )[0]
+    present = observe_runner_queue.observe_once(
+        RUN,
+        [
+            _job(
+                name="wrapper-e2e (macos-15)",
+                created_at="2026-08-28T05:59:30Z",
+            )
+        ],
+        ["wrapper-e2e (macos-15)"],
+        now=NOW,
+        configured_runner="macos-15",
+    )[0]
+
+    assert missing.queue_age is None
+    assert observe_runner_queue.queue_violations([missing], timedelta(seconds=1), missing_visible=False) == []
+    assert present.queue_age == timedelta(seconds=30)
+    assert observe_runner_queue.queue_violations([present], timedelta(minutes=1), missing_visible=True) == []
+
+
+def test_fetches_every_job_page_before_matching_an_expected_job() -> None:
+    class PaginatedApi:
+        def __init__(self) -> None:
+            self.paths: list[str] = []
+
+        def get_json(self, path: str) -> object:
+            self.paths.append(path)
+            if path.endswith("/runs/123"):
+                return RUN
+            if path.endswith("jobs?per_page=100&page=1"):
+                return {"total_count": 101, "jobs": [_job(name="first page")] * 100}
+            if path.endswith("jobs?per_page=100&page=2"):
+                return {"total_count": 101, "jobs": [_job(name="matrix (macos-15)")]}
+            raise AssertionError(path)
+
+    api = PaginatedApi()
+    _run, jobs = observe_runner_queue.fetch_workflow_state(api, "zackees/zccache", 123)
+
+    assert len(jobs) == 101
+    assert api.paths[-1].endswith("jobs?per_page=100&page=2")
+
+
+def test_api_error_is_loud_and_distinct_from_a_queued_job() -> None:
+    class BrokenApi:
+        def get_json(self, _path: str) -> object:
+            raise observe_runner_queue.GitHubApiError("HTTP 503")
+
+    with pytest.raises(observe_runner_queue.GitHubApiError, match="HTTP 503"):
+        observe_runner_queue.fetch_workflow_state(BrokenApi(), "zackees/zccache", 123)

--- a/ci/tests/test_package_release.py
+++ b/ci/tests/test_package_release.py
@@ -35,9 +35,7 @@ stamp_release = _load_stamp_release()
 
 
 def _repo_text(*parts: str) -> str:
-    return (Path(__file__).resolve().parents[2] / Path(*parts)).read_text(
-        encoding="utf-8"
-    )
+    return (Path(__file__).resolve().parents[2] / Path(*parts)).read_text(encoding="utf-8")
 
 
 def _matrix_entry(workflow_text: str, target: str) -> str:
@@ -127,9 +125,7 @@ def test_stage_debug_tree_packages_dwp_files(tmp_path: Path) -> None:
     with tarfile.open(archive, "r:gz") as tf:
         members = {member.name for member in tf.getmembers()}
         for name in package_release.INCLUDE:
-            assert (
-                f"zccache-v1.3.10-x86_64-unknown-linux-gnu-debug/{name}.dwp" in members
-            )
+            assert f"zccache-v1.3.10-x86_64-unknown-linux-gnu-debug/{name}.dwp" in members
 
 
 def test_stage_debug_tree_handles_dsym_directories(tmp_path: Path) -> None:
@@ -154,10 +150,7 @@ def test_stage_debug_tree_handles_dsym_directories(tmp_path: Path) -> None:
 
     with tarfile.open(archive, "r:gz") as tf:
         members = {member.name for member in tf.getmembers()}
-        assert (
-            "zccache-v1.3.10-x86_64-apple-darwin-debug/zccache.dSYM/"
-            "Contents/Resources/DWARF/zccache" in members
-        )
+        assert "zccache-v1.3.10-x86_64-apple-darwin-debug/zccache.dSYM/Contents/Resources/DWARF/zccache" in members
 
 
 def test_build_target_dereferences_debug_sidecar_symlinks() -> None:
@@ -183,12 +176,7 @@ def test_build_target_selects_native_or_cross_release_cache_policy() -> None:
     assert 'cargo_build=(rustup run "$RELEASE_RUST_TOOLCHAIN" cargo build)' in action
     assert "Native distribution builds keep the historical no-cache path" in action
     assert "cross lanes deliberately use the current-worktree bootstrap zccache" in action
-    assert (
-        '"${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache '
-        "--features zccache-bin,fingerprint-bin "
-        "--bin zccache --bin zccache-fp"
-        in compact_action
-    )
+    assert '"${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache --features zccache-bin,fingerprint-bin --bin zccache --bin zccache-fp' in compact_action
     assert "--bin zccache-daemon" not in compact_action
     assert '"${cargo_build[@]}" --release --target ${{ inputs.target }} -p zccache-cli --features python --lib' in action
 
@@ -198,7 +186,7 @@ def test_release_workflow_uses_bootstrap_zccache_for_cross_builds() -> None:
     action = _repo_text(".github/actions/build-target/action.yml")
 
     assert "bootstrap-zccache:" in release_workflow
-    assert "RUSTC_WRAPPER: \"\"" in release_workflow
+    assert 'RUSTC_WRAPPER: ""' in release_workflow
     assert "unset RUSTC_WRAPPER RUSTC_WORKSPACE_WRAPPER" in release_workflow
     assert "name: bootstrap-zccache" in release_workflow
     assert "needs: [preflight, bootstrap-zccache]" in release_workflow
@@ -225,10 +213,7 @@ def test_release_workflow_uses_bootstrap_zccache_for_cross_builds() -> None:
         )
         if "runs-on: ${{ matrix.os }}" in body
     }
-    assert matrix_os_jobs == {"test-wheels", "test-wheels-ungated"}, (
-        "only the wheel smoke jobs may run on a per-target matrix runner; "
-        f"got {sorted(matrix_os_jobs)}"
-    )
+    assert matrix_os_jobs == {"test-wheels", "test-wheels-ungated"}, f"only the wheel smoke jobs may run on a per-target matrix runner; got {sorted(matrix_os_jobs)}"
     assert "if: inputs.use_soldr == 'true'" in action
     assert "Use setup-soldr for setup and caching" in action
 
@@ -248,8 +233,7 @@ def test_release_tests_exec_cached_in_every_native_wheel_family() -> None:
     for platform in (
         "ubuntu-latest",
         "ubuntu-24.04-arm",
-        "macos-15-intel",
-        "macos-14",
+        "macos-15",
         "windows-latest",
         "windows-11-arm",
     ):
@@ -286,9 +270,7 @@ def test_cross_builds_go_through_the_blessed_soldr_surface() -> None:
     # Prose references to cargo-xwin are fine (the upstream fix we are porting
     # lives there); what must not come back is invoking it.
     assert "cargo xwin build" not in action
-    assert "taiki-e/install-action" not in action or "cargo-xwin" not in (
-        action.split("taiki-e/install-action")[1][:200] if "taiki-e/install-action" in action else ""
-    )
+    assert "taiki-e/install-action" not in action or "cargo-xwin" not in (action.split("taiki-e/install-action")[1][:200] if "taiki-e/install-action" in action else "")
     assert "cross_driver" not in action
     assert "zigbuild" not in action
     assert "cargo xwin" not in action
@@ -339,10 +321,7 @@ def test_linux_cross_build_repairs_debug_sidecars_missing_from_cache_hits() -> N
     action = _repo_text(".github/actions/build-target/action.yml")
 
     assert "name: Repair missing Linux debug sidecars" in action
-    assert (
-        "if: inputs.cross_compile == 'true' && "
-        "contains(inputs.target, 'unknown-linux')"
-    ) in action
+    assert ("if: inputs.cross_compile == 'true' && contains(inputs.target, 'unknown-linux')") in action
     assert 'soldr cargo clean -p zccache --release --target "$TARGET"' in action
     assert "soldr --no-cache build --jobs 1 -j 1" in action
     assert 'test -e "$TARGET_DIR/zccache.dwp"' in action
@@ -373,16 +352,11 @@ def test_locked_mimalloc_pprof_selects_arm64_c11_atomics() -> None:
     `CFLAGS=-TP`, which breaks every other `cc-rs` dependency.
     """
     lockfile = _repo_text("Cargo.lock")
-    locked = re.search(
-        r'\[\[package\]\]\nname = "mimalloc-pprof"\nversion = "([^"]+)"', lockfile
-    )
+    locked = re.search(r'\[\[package\]\]\nname = "mimalloc-pprof"\nversion = "([^"]+)"', lockfile)
 
     assert locked is not None, "mimalloc-pprof missing from Cargo.lock"
     major, minor, patch = (int(part) for part in locked.group(1).split(".")[:3])
-    assert (major, minor, patch) >= (0, 9, 3), (
-        f"mimalloc-pprof {locked.group(1)} predates the ARM64 C11-atomics fix; "
-        "aarch64-pc-windows-msvc cannot cross-compile against it"
-    )
+    assert (major, minor, patch) >= (0, 9, 3), f"mimalloc-pprof {locked.group(1)} predates the ARM64 C11-atomics fix; aarch64-pc-windows-msvc cannot cross-compile against it"
 
 
 def test_release_workflow_dry_run_builds_without_publishing() -> None:
@@ -427,7 +401,7 @@ def test_build_target_exposes_cross_cache_controls() -> None:
 def test_build_target_configures_target_c_compiler_for_cross_c_sources() -> None:
     action = _repo_text(".github/actions/build-target/action.yml")
 
-    assert 'TARGET_CC=$(echo "${{ inputs.target }}" | tr \'-\' \'_\')' in action
+    assert "TARGET_CC=$(echo \"${{ inputs.target }}\" | tr '-' '_')" in action
     assert 'echo "CC_${TARGET_CC}=${{ inputs.linker }}" >> "$GITHUB_ENV"' in action
 
 
@@ -476,14 +450,8 @@ def test_release_and_build_workflows_disable_cook_cache_for_linux_cross_matrix()
 
     for workflow in (build_workflow, release_workflow):
         assert "prebuild_deps: ${{ matrix.prebuild_deps || 'soldr-cook' }}" in workflow
-        assert (
-            "clear_target_after_setup: "
-            "${{ matrix.clear_target_after_setup || 'false' }}"
-        ) in workflow
-        assert (
-            "require_debug_sidecars: "
-            "${{ matrix.require_debug_sidecars || 'true' }}"
-        ) in workflow
+        assert ("clear_target_after_setup: ${{ matrix.clear_target_after_setup || 'false' }}") in workflow
+        assert ("require_debug_sidecars: ${{ matrix.require_debug_sidecars || 'true' }}") in workflow
 
         for target in cross_targets:
             block = _matrix_entry(workflow, target)
@@ -583,20 +551,12 @@ def test_action_pins_use_full_length_commit_shas() -> None:
     workflow_dir = Path(__file__).resolve().parents[2] / ".github"
     offenders: list[str] = []
     for path in sorted(workflow_dir.rglob("*.yml")):
-        for number, line in enumerate(
-            path.read_text(encoding="utf-8").splitlines(), start=1
-        ):
+        for number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
             match = re.search(r"uses:\s*\S+@([0-9a-f]{6,})\s*$", line)
             if match and len(match.group(1)) != 40:
-                offenders.append(
-                    f"{path.relative_to(workflow_dir.parent)}:{number} "
-                    f"-> @{match.group(1)} ({len(match.group(1))} chars)"
-                )
+                offenders.append(f"{path.relative_to(workflow_dir.parent)}:{number} -> @{match.group(1)} ({len(match.group(1))} chars)")
 
-    assert not offenders, (
-        "action pins must use the full 40-character commit SHA; "
-        f"GitHub cannot resolve these: {offenders}"
-    )
+    assert not offenders, f"action pins must use the full 40-character commit SHA; GitHub cannot resolve these: {offenders}"
 
 
 def test_pyo3_cdylibs_live_in_dedicated_crates() -> None:
@@ -626,10 +586,7 @@ def test_pyo3_cdylibs_live_in_dedicated_crates() -> None:
         if {"rlib", "cdylib"} <= types:
             offenders.append(manifest.parent.name)
 
-    assert not offenders, (
-        "these crates pair rlib with cdylib; split the cdylib into its own "
-        f"crate so +crt-static never reaches it: {offenders}"
-    )
+    assert not offenders, f"these crates pair rlib with cdylib; split the cdylib into its own crate so +crt-static never reaches it: {offenders}"
 
 
 def test_windows_release_asserts_static_crt_linkage() -> None:
@@ -671,13 +628,5 @@ def test_patch_tables_carry_no_git_sources() -> None:
     """
     patch_tables = tomllib.loads(_repo_text("Cargo.toml")).get("patch", {})
 
-    offenders = [
-        f"[patch.{registry}] {name}"
-        for registry, deps in patch_tables.items()
-        for name, spec in deps.items()
-        if isinstance(spec, dict) and "git" in spec
-    ]
-    assert not offenders, (
-        "patch tables must not pin git sources; "
-        f"publish the fix upstream and depend on the registry instead: {offenders}"
-    )
+    offenders = [f"[patch.{registry}] {name}" for registry, deps in patch_tables.items() for name, spec in deps.items() if isinstance(spec, dict) and "git" in spec]
+    assert not offenders, f"patch tables must not pin git sources; publish the fix upstream and depend on the registry instead: {offenders}"


### PR DESCRIPTION
Closes #1541\n\nMigrates every direct macOS 14 load-bearing consumer to explicit macOS 15 ARM coverage, preserves Intel wheel execution through an x64 Python + Rosetta boundary, and retains #1538's non-blocking publish graph. Adds a tested Python queue observer with complete job pagination, target-identity visibility grace, API-error diagnostics, and independent Ubuntu orchestration for every macOS lane.\n\nValidation:\n- RED → GREEN: observer import/inventory contracts; paginated 101-job fixture; missing→present identity-grace fixture.\n- uv run --no-project --with pytest --with pyyaml python -m pytest ci/tests/test_workflow_permissions.py ci/tests/test_macos_runner_migration.py ci/tests/test_observe_runner_queue.py ci/tests/test_package_release.py ci/tests/test_release_workflow.py -q → 53 passed, 1 skipped.\n- Ruff check/format and git diff --check clean.\n- Independent Terra review, including same-reviewer follow-up: CLEAN (56 passed, 1 skipped).