### PR TITLE
fix(cache): preserve metadata hit destination

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/cached_hit.rs
@@ -248,17 +248,11 @@ pub(super) fn materialize_cached_compile_hit(
                     );
                     return Err(missing_entry(artifact_key_hex));
                 };
-                let target = if requested
-                    .file_name()
-                    .is_some_and(|name| name == std::ffi::OsStr::new(names[i].as_str()))
-                {
-                    requested
-                } else {
-                    requested
-                        .parent()
-                        .map_or_else(|| requested.clone(), |parent| parent.join(&names[i]).into())
-                };
-                targets.push(target);
+                // The cached name identifies the matching payload, but a
+                // metadata-compatible request owns its current Cargo output
+                // destination. Replaying to the observed cold-build name can
+                // leave the requested identity-derived `.rmeta` absent.
+                targets.push(requested);
                 selected_payloads.push(payloads[i].clone());
             }
             (targets, selected_payloads)
@@ -514,12 +508,16 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn rustc_hit_requires_matching_verdict_and_replays_its_streams() {
+    async fn metadata_compatible_rustc_hit_requires_matching_verdict_and_replays_its_streams() {
         let dir = tempfile::tempdir().unwrap();
         let server = crate::daemon::server::tests::bind_isolated_server(dir.path());
         let state = server.state.as_ref();
         let source_path: NormalizedPath = dir.path().join("source.rs").into();
-        let output_path: NormalizedPath = dir.path().join("output.rlib").into();
+        // A Dylint driver can reuse metadata from a cold compilation while
+        // Cargo gives the compatible request a different identity-derived
+        // destination. The cached name chooses the payload; the current
+        // request must choose where that payload lands.
+        let output_path: NormalizedPath = dir.path().join("libfoldhash-new.rmeta").into();
         let cache_path = state.artifact_dir.join("artifact-key_0");
         std::fs::write(&cache_path, b"artifact bytes").unwrap();
         write_authoritative_blob_digest(&cache_path).unwrap();
@@ -534,7 +532,7 @@ mod tests {
             owner_pids: Vec::new(),
         });
         let mut artifact_meta = ArtifactIndex::new(
-            vec!["output.rlib".to_string()],
+            vec!["libfoldhash-cold.rmeta".to_string()],
             vec![14],
             Arc::new(Vec::new()),
             Arc::new(Vec::new()),
@@ -634,6 +632,10 @@ mod tests {
                 && stderr.as_slice() == b"lint diagnostic"
         ));
         assert_eq!(std::fs::read(output_path).unwrap(), b"artifact bytes");
+        assert!(
+            !dir.path().join("libfoldhash-cold.rmeta").exists(),
+            "a metadata-compatible hit must not redirect output to the cached identity"
+        );
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/crates/zccache/tests/daemon_dylint_cache_test.rs
+++ b/crates/zccache/tests/daemon_dylint_cache_test.rs
@@ -322,6 +322,113 @@ async fn nested_dylint_hits_and_invalidates_every_external_input() {
     .await;
 }
 
+/// A Dylint driver's build-style invocation can supply a later Cargo
+/// check-style metadata request through the rustc emit-compat alias.  The
+/// cache entry's cold filename selects the payload, but must never replace the
+/// current request's identity-derived destination.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "integration-level: starts a real daemon and rustc"]
+async fn dylint_metadata_compat_hit_uses_current_cargo_destination() {
+    let Some(rustc) = zccache::test_support::find_rustc() else {
+        eprintln!("skipping test: rustc not found");
+        return;
+    };
+
+    zccache::test_support::test_timeout(async move {
+        let tmp = tempfile::tempdir().unwrap();
+        let cache = tmp.path().join("cache");
+        let _cache_env = CacheDirEnvGuard::set(&cache);
+        let driver = tmp.path().join("dylint-driver");
+        let library = tmp.path().join("libworkspace_lint.so");
+        let source = tmp.path().join("lib.rs");
+        let cold_dir = tmp.path().join("target/debug/deps");
+        let warm_dir = tmp.path().join("target/check/deps");
+        std::fs::create_dir_all(&cold_dir).unwrap();
+        std::fs::create_dir_all(&warm_dir).unwrap();
+        write_driver(&driver, "metadata-compatible Dylint diagnostic");
+        std::fs::write(&library, b"metadata-compatible-lint-library").unwrap();
+        std::fs::write(&source, "pub fn checked() -> u32 { 42 }\n").unwrap();
+
+        let dylint_libs = serde_json::to_string(&vec![library]).unwrap();
+        let cold_metadata = cold_dir.join("libchecked-cold.rmeta");
+        let warm_metadata = warm_dir.join("libchecked-warm.rmeta");
+        let cold_args = vec![
+            rustc.display().to_string(),
+            "--edition=2021".to_string(),
+            "--crate-type=lib".to_string(),
+            "--crate-name=checked".to_string(),
+            "--emit=dep-info,metadata,link".to_string(),
+            "-Cmetadata=cold".to_string(),
+            "-Cextra-filename=-cold".to_string(),
+            "--out-dir".to_string(),
+            cold_dir.display().to_string(),
+            source.display().to_string(),
+        ];
+        let warm_args = vec![
+            rustc.display().to_string(),
+            "--edition=2021".to_string(),
+            "--crate-type=lib".to_string(),
+            "--crate-name=checked".to_string(),
+            "--emit=dep-info,metadata".to_string(),
+            "-Cmetadata=warm".to_string(),
+            "-Cextra-filename=-warm".to_string(),
+            "--out-dir".to_string(),
+            warm_dir.display().to_string(),
+            source.display().to_string(),
+        ];
+
+        let (endpoint, server_handle, shutdown) = start_daemon().await;
+        let mut client = zccache::ipc::connect(&endpoint).await.unwrap();
+        let session_id = start_session(&mut client, None).await;
+
+        let cold = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &cold_args,
+            tmp.path(),
+            &dylint_libs,
+            "same-dylint-verdict",
+            false,
+        )
+        .await;
+        assert_eq!(cold.0, 0, "cold Dylint build should succeed");
+        assert!(!cold.1, "cold Dylint build should populate the cache");
+        let expected_metadata = std::fs::read(&cold_metadata).unwrap();
+        std::fs::remove_file(&cold_metadata).unwrap();
+        assert!(
+            !warm_metadata.exists(),
+            "the distinct Cargo check destination must start absent"
+        );
+
+        let warm = compile(
+            &mut client,
+            &session_id,
+            &driver,
+            &warm_args,
+            tmp.path(),
+            &dylint_libs,
+            "same-dylint-verdict",
+            false,
+        )
+        .await;
+        assert_eq!(warm.0, 0, "metadata-compatible request should succeed");
+        assert!(
+            warm.1,
+            "check-style request must use the cached build artifact"
+        );
+        assert_eq!(std::fs::read(&warm_metadata).unwrap(), expected_metadata);
+        assert!(
+            !cold_metadata.exists(),
+            "a compatible hit must not replay into the stale cold-build destination"
+        );
+
+        shutdown.notify_one();
+        server_handle.await.unwrap();
+    })
+    .await;
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "integration-level: starts a real daemon and rustc"]
 async fn plain_and_dylint_share_artifact_bytes_but_not_verdicts() {


### PR DESCRIPTION
Refs #1545.

A metadata-compatible Rust cache hit now materializes the selected cached payload at the current request's Cargo-owned output path. The cached artifact name is still used only to select the matching payload; it no longer redirects a compatible request to a stale cold-build identity.

Coverage and validation (managed Linux Docker):
- Real Dylint-driver/daemon integration: cold `dep-info,metadata,link` build with a `-cold` Cargo identity, then a distinct `dep-info,metadata` check request with `-warm`; the second response is an actual cache hit, the requested warm `.rmeta` has the cold payload bytes, and the stale cold `.rmeta` remains absent.
- Focused materializer unit test keeps the direct payload-selection and verdict boundary coverage.
- RED: temporarily restoring the 1.13.15 redirect makes both destination assertions fail because the requested `.rmeta` is missing (exit 101).
- GREEN: real integration 1 passed; focused unit 1 passed; `cargo fmt --all -- --check`; scoped daemon-core and integration-test Clippy with `-D warnings`; `git diff --check` all pass.

This PR intentionally does not close #1545: issue closure still requires a patch zccache release with supported release assets, then Soldr's exact embedded dependency update and a fresh authoritative Soldr lane.