### PR TITLE
fix(ci): point the perf entrypoint at a test target that exists

### DIFF
--- a/ci/perf.py
+++ b/ci/perf.py
@@ -24,7 +24,11 @@ def main():
     cmd = cargo_command(
         "test",
         "-p", "zccache",
-        "--test", "daemon_perf_bench_test",
+        # The four benchmarks named in this module's docstring live in the
+        # `perf_bench_test` target (`tests/perf_bench/tests_*.rs`). There has
+        # never been a `daemon_perf_bench_test` target, so `./perf.sh` exited
+        # with `error: no test target named daemon_perf_bench_test`.
+        "--test", "perf_bench_test",
         "--",
         "--nocapture",
         "--ignored",


### PR DESCRIPTION
`ci/perf.py` — the module behind the root `perf.sh` wrapper — ran:

```
cargo test -p zccache --test daemon_perf_bench_test -- --nocapture --ignored --test-threads=1
```

**No such target has ever existed.** `git log --all --diff-filter=D -- 'crates/zccache/tests/daemon_perf_bench_test.rs'` is empty, and the invocation fails immediately:

```
error: no test target named `daemon_perf_bench_test` in `zccache` package
```

So `./perf.sh` has been dead. This is a *loud* failure rather than a silent one, which is presumably why it survived — nobody ran it and mistook a pass for coverage.

## The right target

The four benchmarks this module's own docstring advertises are all in `perf_bench_test`:

```
$ cargo nextest list --test perf_bench_test --run-ignored all
zccache::perf_bench_test perf_bench::tests_c::perf_c_zccache_vs_bare
zccache::perf_bench_test perf_bench::tests_cpp::perf_warm_cache_zccache_vs_sccache
zccache::perf_bench_test perf_bench::tests_response_file::perf_response_file
zccache::perf_bench_test perf_bench::tests_rust::perf_rustc_zccache_vs_sccache
```

That is also where `.github/workflows/perf-guard.yml`, `ci/docker/standalone_perf_entrypoint.sh`, `ci/docker/profile/run_profile.sh` and `run_bosn_profile.sh` already point. `ci/perf.py` was the odd one out.

## Verification

```
$ cargo test -p zccache --test perf_bench_test --no-run
  Executable tests/perf_bench_test.rs (target/debug/deps/perf_bench_test-1063e2d5dbfc8518)
```

Surfaced while auditing every `--test <name>` reference for #1526. It was flagged there rather than guessed at; this PR fixes it now that the docstring and the target listing agree on the intent.