### PR TITLE
fix(daemon): preserve compiler termination signals

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/child_watchdog.rs
+++ b/crates/zccache-daemon-core/src/daemon/child_watchdog.rs
@@ -458,8 +458,10 @@ async fn watchdog_inner_impl(
 /// fires when there has been no output, so stderr is empty by construction.
 /// The caller therefore saw `error: could not compile <crate>` with an empty
 /// cause and no way to tell "your code is broken" from "we shot the compiler".
-/// On Unix the same kill yields `status.code() == None` (reported as `-1`),
-/// which is precisely why this only ever reproduced on Windows (soldr#1857).
+/// On Unix the same kill yields `status.code() == None`; the process facade
+/// preserves its exact signal in the reserved negative namespace. This is
+/// precisely why the empty-diagnostic ambiguity only reproduced on Windows
+/// (soldr#1857).
 ///
 /// Only annotates when the child both failed and said nothing: `stderr_bytes`
 /// counts bytes actually read from the pipe, so it is the honest signal on the
@@ -509,6 +511,7 @@ fn emit_pipe_read_error_diagnostics(
     stderr_bytes: usize,
     status: &ExitStatus,
 ) {
+    let exit = crate::platform::process::exit::outcome(status);
     tracing::warn!(
         event = "child_wait_watchdog_fired",
         stage = "pipe_read_error",
@@ -519,7 +522,8 @@ fn emit_pipe_read_error_diagnostics(
         stderr_failed,
         stdout_bytes,
         stderr_bytes,
-        exit_code = status.code().unwrap_or(-1),
+        exit_code = exit.exit_code,
+        termination_signal = exit.termination_signal,
         "reading the child's output pipe failed; the drain ended early and any          diagnostics still buffered in that pipe are lost. The exit status is          still the child's real one, so a non-zero exit here may carry no          explanation of its own (soldr#1857)."
     );
     crate::core::lifecycle::write_event(
@@ -533,7 +537,8 @@ fn emit_pipe_read_error_diagnostics(
             "stderr_failed": stderr_failed,
             "stdout_bytes": stdout_bytes,
             "stderr_bytes": stderr_bytes,
-            "exit_code": status.code(),
+            "exit_code": exit.exit_code,
+            "termination_signal": exit.termination_signal,
         }),
     );
     // Also record it in the dedicated termination stream so these are
@@ -550,7 +555,8 @@ fn emit_pipe_read_error_diagnostics(
             "stderr_failed": stderr_failed,
             "stdout_bytes": stdout_bytes,
             "stderr_bytes": stderr_bytes,
-            "exit_code": status.code(),
+            "exit_code": exit.exit_code,
+            "termination_signal": exit.termination_signal,
         }),
     );
 }

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/README.md
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/README.md
@@ -25,7 +25,9 @@ unchanged.
   `derive_output_ext`).
 - **outcome.rs** — `extract_outcome`: maps a `Response` to
   `(outcome_str, exit_code, default_miss_reason)`. The canonical translation
-  point for issue #322 (every miss carries a reason).
+  point for issue #322 (every miss carries a reason). Unix compiler signal
+  `N` uses `exit_code == -(128 + N)`; `termination_signal()` supplies the explicit
+  additive JSON field that distinguishes SIGHUP from daemon error `-1`.
 - **journal_thread.rs** — Background writer thread (`journal_thread`),
   `JournalMessage` enum, rotation (`rotate_journal`,
   `JOURNAL_MAX_SIZE`/`JOURNAL_MAX_FILES`), and GC (`gc_journal_files`).

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/mod.rs
@@ -39,7 +39,7 @@ mod tests;
 
 pub use derive::{derive_crate_name, derive_crate_type, derive_output_ext};
 pub use env::{sanitize_journal_env, SanitizedJournalEnv};
-pub use outcome::extract_outcome;
+pub use outcome::{extract_outcome, termination_signal};
 
 use journal_thread::{journal_thread, JournalMessage};
 
@@ -191,8 +191,12 @@ pub struct JournalEntry {
     /// pairs. Secret-bearing and non-allowlisted variables are omitted.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub env: Option<SanitizedJournalEnv>,
-    /// Process exit code (-1 for errors).
+    /// Process exit code. Unix signal `N` is encoded as `-(128 + N)`; `-1`
+    /// remains the legacy/daemon-error sentinel.
     pub exit_code: i32,
+    /// Unix signal that terminated the compiler, when applicable.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub termination_signal: Option<i32>,
     /// Session UUID or null for ephemeral.
     pub session_id: Option<String>,
     /// zackees/soldr#2436 D4: which daemon process generation served this
@@ -315,6 +319,7 @@ impl JournalEntry {
             cwd: ctx.cwd,
             env: ctx.env,
             exit_code,
+            termination_signal: None,
             session_id: ctx.session_id,
             daemon_generation: Some(daemon_generation().to_string()),
             latency_ns,
@@ -331,6 +336,12 @@ impl JournalEntry {
     #[must_use]
     pub fn with_context_key(mut self, context_key: Option<String>) -> Self {
         self.context_key = context_key;
+        self
+    }
+
+    #[must_use]
+    pub fn with_termination_signal(mut self, termination_signal: Option<i32>) -> Self {
+        self.termination_signal = termination_signal;
         self
     }
 

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/outcome.rs
@@ -45,3 +45,16 @@ pub fn extract_outcome(response: &Response) -> Option<(&'static str, i32, Option
         _ => None,
     }
 }
+
+/// Return exact Unix compiler-signal metadata carried by a compile response.
+/// Infrastructure errors remain signal-less even though their sentinel exit
+/// code is also negative.
+#[must_use]
+pub fn termination_signal(response: &Response) -> Option<i32> {
+    match response {
+        Response::CompileResult { exit_code, .. } => {
+            crate::platform::process::exit::termination_signal_from_exit_code(*exit_code)
+        }
+        _ => None,
+    }
+}

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/entry.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/entry.rs
@@ -216,6 +216,17 @@ fn test_serialization_exit_code_boundary_values() {
 }
 
 #[test]
+fn signal_termination_is_explicit_and_additive_in_json() {
+    let entry = JournalEntry::new(make_ctx(vec!["--version"]), "error", -143, 42, None)
+        .with_termination_signal(Some(15));
+
+    let value = serde_json::to_value(entry).expect("serialize signaled compile");
+
+    assert_eq!(value["exit_code"], -143);
+    assert_eq!(value["termination_signal"], 15);
+}
+
+#[test]
 fn test_serialization_latency_precision_boundary() {
     // serde_json::Value stores numbers as i64/u64/f64 internally.
     // Values up to u64::MAX round-trip exactly (stored as u64).
@@ -274,6 +285,7 @@ fn serializes_extended_fields_when_present() {
         cwd: "/project".to_string(),
         env: None,
         exit_code: 0,
+        termination_signal: None,
         session_id: Some("sess-1".to_string()),
         daemon_generation: None,
         latency_ns: 1_234_567,

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/mod.rs
@@ -57,6 +57,7 @@ pub(super) fn legacy_entry(
         cwd: cwd.to_string(),
         env: sanitize_journal_env(env),
         exit_code,
+        termination_signal: None,
         session_id,
         daemon_generation: None,
         latency_ns,

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/outcome.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use crate::protocol::{LookupOutcomes, Response};
 
-use super::super::{extract_outcome, miss_reason};
+use super::super::{extract_outcome, miss_reason, termination_signal};
 
 #[test]
 fn test_extract_outcome_compile_hit() {
@@ -75,6 +75,23 @@ fn test_extract_outcome_error_response() {
         message: "something broke".to_string(),
     };
     assert_eq!(extract_outcome(&resp), Some(("error", -1, None)));
+}
+
+#[cfg(unix)]
+#[test]
+fn compile_signal_is_distinct_from_daemon_error() {
+    let compile = Response::CompileResult {
+        exit_code: -143,
+        stdout: Arc::new(Vec::new()),
+        stderr: Arc::new(Vec::new()),
+        cached: false,
+    };
+    let daemon_error = Response::Error {
+        message: "spawn failed".to_string(),
+    };
+
+    assert_eq!(termination_signal(&compile), Some(15));
+    assert_eq!(termination_signal(&daemon_error), None);
 }
 
 #[test]

--- a/crates/zccache-daemon-core/src/daemon/compile_journal/tests/outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/compile_journal/tests/outcome.rs
@@ -4,7 +4,9 @@ use std::sync::Arc;
 
 use crate::protocol::{LookupOutcomes, Response};
 
-use super::super::{extract_outcome, miss_reason, termination_signal};
+#[cfg(unix)]
+use super::super::termination_signal;
+use super::super::{extract_outcome, miss_reason};
 
 #[test]
 fn test_extract_outcome_compile_hit() {

--- a/crates/zccache-daemon-core/src/daemon/server/connection/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/connection/mod.rs
@@ -450,6 +450,7 @@ pub(super) async fn handle_connection(
                 attributed_miss_reason,
                 context_key,
             } = pending;
+            let termination_signal = crate::daemon::compile_journal::termination_signal(&response);
             let (outcome, exit_code, miss_reason) = extract_outcome(&response)?;
             let latency_ns = journal_start.elapsed().as_nanos();
             let miss_reason = compile_miss_reason(
@@ -477,9 +478,10 @@ pub(super) async fn handle_connection(
                 session_journal_path,
                 profile_on,
                 context_key,
+                termination_signal,
             ))
         });
-        if let Some((ctx, _, _, latency_ns, reason, _, _, _)) = journal_payload.as_ref() {
+        if let Some((ctx, _, _, latency_ns, reason, _, _, _, _)) = journal_payload.as_ref() {
             if *reason == Some(miss_reason::UNKNOWN) {
                 append_unknown_miss_warning(&mut response, ctx, *latency_ns);
             }
@@ -499,10 +501,12 @@ pub(super) async fn handle_connection(
             session_journal_path,
             profile_on,
             context_key,
+            termination_signal,
         )) = journal_payload
         {
             let entry = JournalEntry::new(ctx, outcome, exit_code, latency_ns, miss_reason)
-                .with_context_key(context_key);
+                .with_context_key(context_key)
+                .with_termination_signal(termination_signal);
             // Issue #256: extended-journal fields are populated only
             // for sessions that opted in via session-start --profile.
             //

--- a/crates/zccache-daemon-core/src/daemon/server/embedded.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/embedded.rs
@@ -312,6 +312,7 @@ impl EmbeddedDaemon {
         // above plus serde serialization — parity with the IPC path's
         // accepted cost (issue #459).
         if let Some((outcome, exit_code, default_reason)) = extract_outcome(&response) {
+            let termination_signal = crate::daemon::compile_journal::termination_signal(&response);
             let latency_ns = total.elapsed().as_nanos();
             let miss_reason = super::connection::compile_miss_reason(
                 &journal_ctx,
@@ -328,7 +329,8 @@ impl EmbeddedDaemon {
                 );
             }
             let entry = JournalEntry::new(journal_ctx, outcome, exit_code, latency_ns, miss_reason)
-                .with_context_key(context_key);
+                .with_context_key(context_key)
+                .with_termination_signal(termination_signal);
             self.state.journal.log(&entry, None);
         }
         match response {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -415,11 +415,9 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
 
     if state.compile_concurrency.is_some() {
         let duration_ns = compile_span_start.elapsed().as_nanos() as u64;
-        let exit_code = result
-            .as_ref()
-            .ok()
-            .and_then(|o| o.status.code())
-            .unwrap_or(-1);
+        let exit_code = result.as_ref().map_or(-1, |output| {
+            crate::platform::process::exit::outcome(&output.status).exit_code
+        });
         tracing::info!(
             event = "compile_end",
             client_pid,
@@ -450,7 +448,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let compiler_prep_ns = compiler_exec_ns.saturating_sub(compiler_process_ns);
 
     let t_post_exec = std::time::Instant::now();
-    let exit_code = output.status.code().unwrap_or(-1);
+    let exit_code = crate::platform::process::exit::outcome(&output.status).exit_code;
     let (stdout_bytes, dependency_scan, stderr_bytes) = if let Some(streamed) = streamed_output {
         (streamed.stdout, streamed.dependency_scan, streamed.stderr)
     } else if depfile_strategy == DepfileStrategy::ShowIncludes {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
@@ -215,7 +215,7 @@ pub(super) async fn run_compiler_direct_with_family(
                     }
                 }
             }
-            let exit_code = output.status.code().unwrap_or(-1);
+            let exit_code = crate::platform::process::exit::outcome(&output.status).exit_code;
             write_session_log(sessions, sid, &format!("[DIRECT] exit_code={exit_code}"));
             Response::CompileResult {
                 exit_code,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -795,7 +795,7 @@ pub(super) async fn handle_compile_multi(
         }
     };
 
-    let exit_code = output.status.code().unwrap_or(-1);
+    let exit_code = crate::platform::process::exit::outcome(&output.status).exit_code;
     all_stdout.extend_from_slice(&output.stdout);
     all_stderr.extend_from_slice(&output.stderr);
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -255,11 +255,9 @@ pub(super) async fn try_handle_staged_misses(
             let output = process::tokio_command_output_with_priority(&mut command, priority).await;
             let elapsed_ns = compiler_started.elapsed().as_nanos() as u64;
             if admission_state.compile_concurrency.is_some() {
-                let exit_code = output
-                    .as_ref()
-                    .ok()
-                    .and_then(|value| value.status.code())
-                    .unwrap_or(-1);
+                let exit_code = output.as_ref().map_or(-1, |value| {
+                    crate::platform::process::exit::outcome(&value.status).exit_code
+                });
                 tracing::info!(
                     event = "compile_end",
                     client_pid,
@@ -321,7 +319,7 @@ pub(super) async fn try_handle_staged_misses(
             crate::daemon::staged_stats::StagedTiming::Compiler,
             elapsed_ns,
         );
-        let exit_code = output.status.code().unwrap_or(-1);
+        let exit_code = crate::platform::process::exit::outcome(&output.status).exit_code;
         let stderr = if miss.plan.msvc_syntax {
             let (scan_result, filtered_stderr) =
                 crate::depgraph::show_includes::parse_show_includes(

--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -24,6 +24,7 @@ pub use control::EmbeddedEventSink;
 
 mod control;
 mod reporting;
+mod termination;
 
 /// Result type used by the embedded service API.
 pub type Result<T> = std::result::Result<T, EmbeddedError>;
@@ -304,7 +305,9 @@ pub enum CompileChunk {
     Stdout(Vec<u8>),
     /// A chunk of compiler stderr bytes.
     Stderr(Vec<u8>),
-    /// Terminal event with the compile's outcome metadata.
+    /// Terminal event with the compile's outcome metadata. Unix signal
+    /// termination uses the same reserved negative `exit_code` representation
+    /// as [`CompileResponse`].
     Done {
         exit_code: i32,
         cached: bool,
@@ -775,21 +778,7 @@ impl ZccacheService {
             // below carries the exit code.
             CacheOutcome::Error => {}
         }
-        self.emit_audit(
-            &audit,
-            crate::audit::AuditCategory::ZCCACHE_COMPILE,
-            crate::audit::AuditEventName::COMPILE_FINISHED,
-            if response.exit_code == 0 {
-                crate::audit::AuditLevel::Info
-            } else {
-                crate::audit::AuditLevel::Error
-            },
-            Some(elapsed_ns),
-            &[
-                ("exit_code", serde_json::Value::from(response.exit_code)),
-                ("cached", serde_json::Value::from(response.cached)),
-            ],
-        );
+        termination::emit_compile_finished(self, &audit, &response, elapsed_ns);
         Ok(CompileResponse {
             exit_code: response.exit_code,
             stdout: response.stdout.as_ref().clone(),

--- a/crates/zccache-daemon-core/src/embedded/termination.rs
+++ b/crates/zccache-daemon-core/src/embedded/termination.rs
@@ -1,0 +1,199 @@
+//! Compiler-termination projection for embedded audit events.
+
+use crate::daemon::server::EmbeddedCompileResult;
+
+pub(super) fn emit_compile_finished(
+    service: &super::ZccacheService,
+    audit: &crate::audit::AuditContext,
+    response: &EmbeddedCompileResult,
+    duration_ns: u64,
+) {
+    if service.audit_sink.is_none() && service.event_sink.is_none() {
+        return;
+    }
+    let base_fields = [
+        ("exit_code", serde_json::Value::from(response.exit_code)),
+        ("cached", serde_json::Value::from(response.cached)),
+    ];
+    let level = if response.exit_code == 0 {
+        crate::audit::AuditLevel::Info
+    } else {
+        crate::audit::AuditLevel::Error
+    };
+    if let Some(signal) =
+        crate::platform::process::exit::termination_signal_from_exit_code(response.exit_code)
+    {
+        let fields = [
+            ("exit_code", serde_json::Value::from(response.exit_code)),
+            ("cached", serde_json::Value::from(response.cached)),
+            ("termination_signal", serde_json::Value::from(signal)),
+        ];
+        service.emit_audit(
+            audit,
+            crate::audit::AuditCategory::ZCCACHE_COMPILE,
+            crate::audit::AuditEventName::COMPILE_FINISHED,
+            level,
+            Some(duration_ns),
+            &fields,
+        );
+    } else {
+        service.emit_audit(
+            audit,
+            crate::audit::AuditCategory::ZCCACHE_COMPILE,
+            crate::audit::AuditEventName::COMPILE_FINISHED,
+            level,
+            Some(duration_ns),
+            &base_fields,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    fn response(exit_code: i32) -> EmbeddedCompileResult {
+        EmbeddedCompileResult {
+            exit_code,
+            stdout: Arc::new(Vec::new()),
+            stderr: Arc::new(Vec::new()),
+            cached: false,
+        }
+    }
+
+    #[test]
+    fn response_encoding_recovers_only_exact_signals() {
+        assert_eq!(response(-143).exit_code, -143);
+        assert_eq!(
+            crate::platform::process::exit::termination_signal_from_exit_code(-143),
+            Some(15)
+        );
+        for exit_code in [0, 1, -1] {
+            assert_eq!(
+                crate::platform::process::exit::termination_signal_from_exit_code(exit_code),
+                None
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    fn find_named_file(dir: &std::path::Path, name: &str) -> Option<std::path::PathBuf> {
+        for entry in std::fs::read_dir(dir).ok()?.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(found) = find_named_file(&path, name) {
+                    return Some(found);
+                }
+            } else if path.file_name().and_then(|value| value.to_str()) == Some(name) {
+                return Some(path);
+            }
+        }
+        None
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cacheable_rust_compile_preserves_signal_in_response_journal_and_audit() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = tempfile::TempDir::new().expect("temp root");
+        let compiler = temp.path().join("rustc");
+        let count = temp.path().join("compile-count");
+        let source = temp.path().join("signal.rs");
+        let output = temp.path().join("libsignal.rmeta");
+        std::fs::write(&source, "pub fn signal_fixture() {}\n").expect("source");
+        std::fs::write(
+            &compiler,
+            "#!/bin/sh\nif [ \"$1\" = \"-vV\" ]; then\n  printf 'rustc 1.95.0 (fixture 2026-01-01)\\nbinary: rustc\\ncommit-hash: fixture\\ncommit-date: 2026-01-01\\nhost: x86_64-unknown-linux-gnu\\nrelease: 1.95.0\\nLLVM version: 20.1.0\\n'\n  exit 0\nfi\nprintf x >> \"$ZCCACHE_SIGNAL_COUNT\"\nkill -TERM $$\n",
+        )
+        .expect("compiler script");
+        std::fs::set_permissions(&compiler, std::fs::Permissions::from_mode(0o755))
+            .expect("make compiler executable");
+
+        let service = super::super::ZccacheService::start(super::super::ZccacheConfig {
+            host: super::super::HostIdentity {
+                product: "signal-test".into(),
+                instance_id: "cacheable-rust-signal".into(),
+                workspace_id: "cacheable-rust-signal".into(),
+            },
+            cache_root: temp.path().join("cache").into(),
+            audit: super::super::AuditConfig {
+                output_root: Some(temp.path().join("audit").to_string_lossy().into_owned()),
+                ..super::super::AuditConfig::default()
+            },
+            limits: super::super::ServiceLimits::default(),
+            runtime: super::super::RuntimeHooks::default(),
+            cancellation: None,
+        })
+        .await
+        .expect("service start");
+        let request = super::super::CompileRequest {
+            audit: super::super::AuditContext::new(
+                crate::audit::AuditId::new("signal-run").expect("run id"),
+                crate::audit::AuditId::new("signal-trace").expect("trace id"),
+            ),
+            compiler: compiler.into(),
+            args: vec![
+                source.to_string_lossy().into_owned(),
+                "--crate-name".into(),
+                "signal_fixture".into(),
+                "--crate-type".into(),
+                "lib".into(),
+                "--emit=dep-info,metadata".into(),
+                "-o".into(),
+                output.to_string_lossy().into_owned(),
+            ],
+            cwd: temp.path().into(),
+            env: vec![(
+                "ZCCACHE_SIGNAL_COUNT".into(),
+                count.to_string_lossy().into_owned(),
+            )],
+            stdin: Vec::new(),
+        };
+
+        for _ in 0..2 {
+            let response = service
+                .compile(request.clone())
+                .await
+                .expect("signal is a compiler response");
+            assert_eq!(response.exit_code, -143);
+            assert!(!response.cached);
+        }
+        let stats = service.stats().await.expect("stats");
+        assert_eq!(stats.non_cacheable, 0, "request must use compile_exec");
+        assert_eq!(std::fs::read(&count).expect("compile count"), b"xx");
+        service.flush().await.expect("flush audit");
+
+        let audit_path = find_named_file(temp.path(), "audit.jsonl").expect("audit log");
+        let audit = std::fs::read_to_string(audit_path).expect("read audit");
+        assert!(audit.lines().any(|line| {
+            let value: serde_json::Value = serde_json::from_str(line).expect("audit JSON");
+            value["event"] == "compile.finished" && value["fields"]["termination_signal"] == 15
+        }));
+
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(5);
+        loop {
+            let found = find_named_file(temp.path(), "compile_journal.jsonl")
+                .and_then(|path| std::fs::read_to_string(path).ok())
+                .is_some_and(|journal| {
+                    journal.lines().any(|line| {
+                        let value: serde_json::Value =
+                            serde_json::from_str(line).expect("journal JSON");
+                        value["exit_code"] == -143 && value["termination_signal"] == 15
+                    })
+                });
+            if found {
+                break;
+            }
+            assert!(std::time::Instant::now() < deadline, "signal journal row");
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
+        service
+            .shutdown(super::super::ShutdownMode::Graceful)
+            .await
+            .expect("shutdown");
+    }
+}

--- a/crates/zccache-daemon-core/src/embedded/termination.rs
+++ b/crates/zccache-daemon-core/src/embedded/termination.rs
@@ -66,9 +66,15 @@ mod tests {
     #[test]
     fn response_encoding_recovers_only_exact_signals() {
         assert_eq!(response(-143).exit_code, -143);
+        #[cfg(unix)]
         assert_eq!(
             crate::platform::process::exit::termination_signal_from_exit_code(-143),
             Some(15)
+        );
+        #[cfg(windows)]
+        assert_eq!(
+            crate::platform::process::exit::termination_signal_from_exit_code(-143),
+            None
         );
         for exit_code in [0, 1, -1] {
             assert_eq!(

--- a/crates/zccache-daemon-core/src/embedded/tests.rs
+++ b/crates/zccache-daemon-core/src/embedded/tests.rs
@@ -484,6 +484,56 @@ mod journal_tests {
         }
     }
 
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn embedded_compile_preserves_exact_termination_signal() {
+        use std::os::unix::fs::PermissionsExt as _;
+
+        let temp = TempDir::new().expect("temp cache root");
+        let compiler = temp.path().join("signal-compiler");
+        std::fs::write(&compiler, "#!/bin/sh\nkill -TERM $$\n").expect("write compiler");
+        std::fs::set_permissions(&compiler, std::fs::Permissions::from_mode(0o755))
+            .expect("make compiler executable");
+        let mut audit = AuditConfig::default();
+        audit.mode = crate::audit::AuditMode::Off;
+        let service = ZccacheService::start(ZccacheConfig {
+            host: HostIdentity {
+                product: "zccache-test".into(),
+                instance_id: "embedded-signal".into(),
+                workspace_id: "embedded-signal".into(),
+            },
+            cache_root: temp.path().join("zccache").into(),
+            audit,
+            limits: ServiceLimits::default(),
+            runtime: RuntimeHooks::default(),
+            cancellation: None,
+        })
+        .await
+        .expect("service start");
+        let response = service
+            .compile(CompileRequest {
+                audit: AuditContext::new(
+                    crate::audit::AuditId::new("signal-run").expect("non-empty"),
+                    crate::audit::AuditId::new("signal-trace").expect("non-empty"),
+                ),
+                compiler: compiler.into(),
+                args: Vec::new(),
+                cwd: temp.path().into(),
+                env: Vec::new(),
+                stdin: Vec::new(),
+            })
+            .await
+            .expect("signaled compiler returns a compile response");
+
+        assert_eq!(response.exit_code, -143);
+        assert_eq!(response.cache_outcome, CacheOutcome::Error);
+
+        service
+            .shutdown(ShutdownMode::Graceful)
+            .await
+            .expect("shutdown service");
+    }
+
     #[tokio::test]
     async fn embedded_compile_writes_compile_journal() {
         let temp = TempDir::new().expect("temp cache root");

--- a/crates/zccache-platform/src/platform/process/exit.rs
+++ b/crates/zccache-platform/src/platform/process/exit.rs
@@ -1,5 +1,36 @@
 //! Native exit and crash interpretation.
 
+/// Portable child-process termination metadata.
+///
+/// Normal exits retain their compiler-provided code. Unix signal exits use
+/// `-(128 + signal)`, reserving `-1` for legacy unknown termination while
+/// preserving the exact signal without widening established response types.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ExitOutcome {
+    pub exit_code: i32,
+    pub termination_signal: Option<i32>,
+}
+
+#[must_use]
+pub fn outcome(status: &std::process::ExitStatus) -> ExitOutcome {
+    let termination_signal = crate::platform_imp::process::exit::termination_signal(status);
+    let exit_code = termination_signal.map_or_else(
+        || status.code().unwrap_or(-1),
+        |signal| -(128_i32.saturating_add(signal)),
+    );
+    ExitOutcome {
+        exit_code,
+        termination_signal,
+    }
+}
+
+/// Recover Unix signal metadata from the portable negative-signal response
+/// encoding. Windows never treats a negative native exit code as a signal.
+#[must_use]
+pub fn termination_signal_from_exit_code(exit_code: i32) -> Option<i32> {
+    crate::platform_imp::process::exit::termination_signal_from_exit_code(exit_code)
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum NativeExit {
     Success,

--- a/crates/zccache-platform/src/platform/process/tests.rs
+++ b/crates/zccache-platform/src/platform/process/tests.rs
@@ -34,6 +34,39 @@ fn disposable_child_output_and_exit_status_are_observable() {
     assert!(String::from_utf8_lossy(&output.stdout).contains("zccache-platform-child"));
 }
 
+#[cfg(unix)]
+#[test]
+fn signal_termination_is_preserved_in_the_reserved_negative_namespace() {
+    let status = std::process::Command::new("sh")
+        .args(["-c", "kill -TERM $$"])
+        .status()
+        .expect("spawn signal-terminated child");
+
+    let outcome = exit::outcome(&status);
+
+    assert_eq!(outcome.exit_code, -143);
+    assert_eq!(outcome.termination_signal, Some(15));
+    assert_eq!(exit::termination_signal_from_exit_code(-1), None);
+    assert_eq!(exit::termination_signal_from_exit_code(-128), None);
+    assert_eq!(exit::termination_signal_from_exit_code(i32::MIN), None);
+}
+
+#[cfg(windows)]
+#[test]
+fn negative_windows_status_remains_native_and_signal_less() {
+    use std::os::windows::process::ExitStatusExt as _;
+
+    let status = std::process::ExitStatus::from_raw(0xC000_0005);
+    let outcome = exit::outcome(&status);
+
+    assert_eq!(outcome.exit_code, 0xC000_0005_u32 as i32);
+    assert_eq!(outcome.termination_signal, None);
+    assert_eq!(
+        exit::termination_signal_from_exit_code(outcome.exit_code),
+        None
+    );
+}
+
 #[test]
 fn child_cpu_ticks_are_nondecreasing() {
     let mut child = spawn::sleeping_child(Duration::from_secs(30)).expect("spawn child");

--- a/crates/zccache-platform/src/platform_linux/process/exit.rs
+++ b/crates/zccache-platform/src/platform_linux/process/exit.rs
@@ -1,5 +1,18 @@
 //! Linux exit interpretation.
 
+use std::os::unix::process::ExitStatusExt as _;
+
+pub fn termination_signal(status: &std::process::ExitStatus) -> Option<i32> {
+    status.signal()
+}
+
+pub fn termination_signal_from_exit_code(exit_code: i32) -> Option<i32> {
+    exit_code
+        .checked_neg()
+        .and_then(|encoded| encoded.checked_sub(128))
+        .filter(|signal| (1..=127).contains(signal))
+}
+
 pub fn context_label(context: &crash_handler::CrashContext) -> String {
     match context.siginfo.ssi_signo as i32 {
         libc::SIGSEGV => "SIGSEGV".to_string(),

--- a/crates/zccache-platform/src/platform_macos/process/exit.rs
+++ b/crates/zccache-platform/src/platform_macos/process/exit.rs
@@ -1,5 +1,18 @@
 //! macOS exit interpretation.
 
+use std::os::unix::process::ExitStatusExt as _;
+
+pub fn termination_signal(status: &std::process::ExitStatus) -> Option<i32> {
+    status.signal()
+}
+
+pub fn termination_signal_from_exit_code(exit_code: i32) -> Option<i32> {
+    exit_code
+        .checked_neg()
+        .and_then(|encoded| encoded.checked_sub(128))
+        .filter(|signal| (1..=127).contains(signal))
+}
+
 pub fn context_label(context: &crash_handler::CrashContext) -> String {
     match context.exception.as_ref() {
         Some(exception) => format!("EXC_{}", exception.kind),

--- a/crates/zccache-platform/src/platform_win/process/exit.rs
+++ b/crates/zccache-platform/src/platform_win/process/exit.rs
@@ -1,5 +1,13 @@
 //! Windows exit interpretation.
 
+pub fn termination_signal(_status: &std::process::ExitStatus) -> Option<i32> {
+    None
+}
+
+pub fn termination_signal_from_exit_code(_exit_code: i32) -> Option<i32> {
+    None
+}
+
 pub fn context_label(context: &crash_handler::CrashContext) -> String {
     let code = exception_code(context);
     match code {

--- a/crates/zccache-protocol/src/messages/compat/ephemeral.rs
+++ b/crates/zccache-protocol/src/messages/compat/ephemeral.rs
@@ -88,7 +88,8 @@ fn existing_response_variants_still_work() {
     roundtrip(&Response::Pong);
     roundtrip(&Response::ShuttingDown);
     roundtrip(&Response::CompileResult {
-        exit_code: 0,
+        // SIGTERM in the wire-compatible reserved negative namespace.
+        exit_code: -143,
         stdout: Arc::new(vec![]),
         stderr: Arc::new(vec![]),
         cached: true,

--- a/crates/zccache/tests/wire/daemon_wire_prost_roundtrip.rs
+++ b/crates/zccache/tests/wire/daemon_wire_prost_roundtrip.rs
@@ -494,7 +494,7 @@ mod full_family {
     #[test]
     fn compile_result_response_roundtrips() {
         roundtrip_response(Response::CompileResult {
-            exit_code: 1,
+            exit_code: -143,
             stdout: Arc::new(b"warning".to_vec()),
             stderr: Arc::new(b"error".to_vec()),
             cached: true,

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -281,6 +281,7 @@ pub struct CompileRequest {
 }
 
 pub struct CompileResponse {
+    // Unix signal N is -(128 + N); normal and Windows exits are unchanged.
     pub exit_code: i32,
     pub stdout: Vec<u8>,
     pub stderr: Vec<u8>,
@@ -405,6 +406,14 @@ that collects the same chunks. Compiler misses and direct invocations emit
 output while the child is running; cache hits replay stored output in 64 KiB
 chunks. Ordering is preserved within stdout and stderr, while cross-stream
 ordering follows the runtime pipe drain.
+
+Compiler termination metadata is preserved without widening the established
+response or wire shape: Unix signal `N` is returned as
+`exit_code == -(128 + N)`.
+Normal compiler exits and Windows process exits retain their native code. The
+durable compile journal additionally emits `termination_signal: N`, which
+distinguishes compiler SIGHUP (`exit_code: -129`) from the legacy/daemon-error
+`-1` sentinel.
 
 The callback runs inline. A slow callback therefore applies backpressure to a
 bounded channel and eventually to the compiler pipes. Retained output is capped

--- a/docs/architecture/kernal-api-migration.toml
+++ b/docs/architecture/kernal-api-migration.toml
@@ -86,7 +86,7 @@ disposition = "extend"
 kernel_capability = "semantic command presentation and containment preparation"
 [[platform_group]]
 source = "crates/zccache-platform/src/platform/process/exit.rs"
-items = ["NativeExit", "crash_label", "context_label", "context_summary"]
+items = ["NativeExit", "ExitOutcome", "outcome", "termination_signal_from_exit_code", "crash_label", "context_label", "context_summary"]
 disposition = "extend"
 kernel_capability = "native exit and crash-context classification"
 [[platform_group]]

--- a/docs/journal-schema.md
+++ b/docs/journal-schema.md
@@ -16,7 +16,8 @@ scripts) can rely on.
 | `args`         | array of string | yes            | Full argument list, suitable for diagnostic replay when combined with an independently captured environment. |
 | `cwd`          | string          | yes            | Working directory at request time. |
 | `env`          | array of `[k, v]` | no           | Sanitized build-diagnostic allowlist. Secret-looking names/values and all non-allowlisted variables are omitted. |
-| `exit_code`    | integer         | yes            | Process exit code. `-1` is reserved for daemon-side errors. |
+| `exit_code`    | integer         | yes            | Process exit code. Unix signal `N` is encoded as `-(128 + N)`; `-1` remains the legacy/daemon-error sentinel. |
+| `termination_signal` | integer   | no             | Exact Unix signal that terminated the compiler. Omitted for normal exits, Windows exits, and daemon-side errors. |
 | `session_id`   | string \| null  | yes            | UUID for session-attached requests; `null` for ephemeral. |
 | `daemon_generation` | string     | no             | Which daemon process generation served the compile (zackees/soldr#2436 D4). The embedded host passes its route-generation identity; a standalone daemon mints one per-process UUID. Restart-warmth analysis joins rows to generations with it. |
 | `latency_ns`   | integer         | yes            | Wall-clock nanoseconds (per the project's `_ns` convention). |

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,13 @@
+# soldr#3031 preserve compiler termination signals
+
+- [x] Read the embedded-service, journal, protocol, and portability contracts.
+- [x] Trace the signal-loss boundary across single, direct, multi-source, staged-multi, embedded, IPC, and journal paths.
+- [x] RED: prove Unix signal termination remains distinguishable from daemon-side errors in the canonical process-status representation and compile journal.
+- [x] GREEN: preserve termination metadata through every compiler response path, the embedded API, audit events, and the durable journal without changing successful/error-cache semantics.
+- [x] Cover protobuf/bincode compatibility; the reserved integer encoding leaves both wire shapes unchanged, so no protocol bump is required.
+- [x] Run focused tests, formatter, clippy/check, and broader compile-path validation. All signal-path tests pass; the full daemon-core suite has one unrelated filesystem-matrix mtime assertion that reproduces alone on macOS.
+- [ ] Review, push, open and merge the linked zccache PR, publish a patch release, then update Soldr's exact pin and six release assets.
+
 # #1539 embedded host compiler-admission classifier
 
 - [x] Read the issue, service admission paths, and embedded configuration surface.


### PR DESCRIPTION
Fixes the signal-loss root cause observed in zackees/soldr#3031 and unblocks the Soldr CI investigation in zackees/soldr#3024.

Unix compiler signal N is encoded as -(128 + N) inside the existing CompileResult exit_code, so bincode/prost/FrameV1 and the embedded API retain their current shape. The compile journal and embedded audit also emit an additive termination_signal field. Normal and Windows exits are unchanged; legacy -1 stays ambiguous/unknown.

Covered paths:
- cacheable single-file compile
- direct/ephemeral compile
- legacy multi-source compile
- staged multi-source compile and trace
- embedded response, audit, and journal
- bincode/prost round trips
- Unix and Windows process-status semantics

Validation:
- zccache-platform: 41 passed
- cacheable rustc-shaped signal E2E: passed twice-executes/never-caches + response/audit/journal assertions
- focused journal, embedded, bincode, and prost tests: passed
- clippy -D warnings for platform, daemon-core, and protocol: passed
- full daemon-core: 824 passed, 28 ignored; one unrelated existing filesystem_materialization_matrix_prints_loud_summary mtime assertion fails reproducibly on macOS (expected synthetic 1000000000, observed current timestamp)

Scope note: this preserves the exact signal in daemon responses, embedded consumers, audit, and journals. The standalone CLI still maps daemon verdict integers to an ordinary process ExitCode; exact self-signal re-raise is intentionally outside this Soldr-focused fix.