### PR TITLE
chore(release): bump 1.13.16 to 1.13.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "bincode",
  "blake3",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "bincode",
  "blake3",
@@ -4320,14 +4320,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "clang",
  "serde_json",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "bincode",
  "blake3",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "blake3",
  "futures",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "bincode",
  "bytes",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "filetime",
  "fs2",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint-py"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "reqwest",
  "serde",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4520,7 +4520,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "blake3",
  "bytes",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-platform"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "crash-handler",
  "interprocess",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "bincode",
  "bytes",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "tempfile",
  "zccache-audit",
@@ -4589,7 +4589,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "globset",
  "jwalk",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher-py"
-version = "1.13.16"
+version = "1.13.17"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.16"
+version = "1.13.17"
 edition = "2021"
 rust-version = "1.95.0"
 license = "AGPL-3.0-only"

--- a/crates/zccache-daemon-core/src/embedded/termination.rs
+++ b/crates/zccache-daemon-core/src/embedded/termination.rs
@@ -66,15 +66,10 @@ mod tests {
     #[test]
     fn response_encoding_recovers_only_exact_signals() {
         assert_eq!(response(-143).exit_code, -143);
-        #[cfg(unix)]
+        let expected = (!crate::platform::host::is_windows()).then_some(15);
         assert_eq!(
             crate::platform::process::exit::termination_signal_from_exit_code(-143),
-            Some(15)
-        );
-        #[cfg(windows)]
-        assert_eq!(
-            crate::platform::process::exit::termination_signal_from_exit_code(-143),
-            None
+            expected
         );
         for exit_code in [0, 1, -1] {
             assert_eq!(
@@ -84,7 +79,6 @@ mod tests {
         }
     }
 
-    #[cfg(unix)]
     fn find_named_file(dir: &std::path::Path, name: &str) -> Option<std::path::PathBuf> {
         for entry in std::fs::read_dir(dir).ok()?.flatten() {
             let path = entry.path();
@@ -99,10 +93,11 @@ mod tests {
         None
     }
 
-    #[cfg(unix)]
     #[tokio::test]
     async fn cacheable_rust_compile_preserves_signal_in_response_journal_and_audit() {
-        use std::os::unix::fs::PermissionsExt as _;
+        if crate::platform::host::is_windows() {
+            return;
+        }
 
         let temp = tempfile::TempDir::new().expect("temp root");
         let compiler = temp.path().join("rustc");
@@ -115,7 +110,7 @@ mod tests {
             "#!/bin/sh\nif [ \"$1\" = \"-vV\" ]; then\n  printf 'rustc 1.95.0 (fixture 2026-01-01)\\nbinary: rustc\\ncommit-hash: fixture\\ncommit-date: 2026-01-01\\nhost: x86_64-unknown-linux-gnu\\nrelease: 1.95.0\\nLLVM version: 20.1.0\\n'\n  exit 0\nfi\nprintf x >> \"$ZCCACHE_SIGNAL_COUNT\"\nkill -TERM $$\n",
         )
         .expect("compiler script");
-        std::fs::set_permissions(&compiler, std::fs::Permissions::from_mode(0o755))
+        crate::platform::fs::permissions::make_executable(&compiler)
             .expect("make compiler executable");
 
         let service = super::super::ZccacheService::start(super::super::ZccacheConfig {


### PR DESCRIPTION
Publishes the compiler termination-signal preservation from #1553 as zccache 1.13.17.\n\nValidation:\n- workspace package versions refreshed in Cargo.lock\n- git diff --check\n- #1553 platform, protocol, daemon-core, formatting, MSRV, and Windows compile checks passed before merge\n\nThe release workflow will build and publish the six platform support archives after merge.