### PR TITLE
fix(admission): include Rust pre-hashing in exclusive access

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -32,7 +32,7 @@ pub(super) struct CompileExecOutcome {
     pub(super) stderr: Arc<Vec<u8>>,
     pub(super) depfile_strategy: DepfileStrategy,
     pub(super) dependency_scan: Option<crate::depgraph::ScanResult>,
-    pub(super) pre_hash_task: Option<tokio::task::JoinHandle<HashMap<NormalizedPath, ContentHash>>>,
+    pub(super) pre_hashed: Option<HashMap<NormalizedPath, ContentHash>>,
     pub(super) compiler_priority_decision: crate::daemon::process::CompilePriorityDecision,
     pub(super) pre_exec_ns: u64,
     pub(super) break_outputs_ns: u64,
@@ -59,9 +59,10 @@ impl Drop for PrivateHeaderTrace {
 }
 
 /// Prepare depfile/response-file/output-paths, spawn the compiler, and gather
-/// timings. The `pre_hash_task` returned is the rustc-only background hash of
-/// source + externs (issue #532) — `await`ed later in the store phase so its
-/// work overlaps with the compiler process itself.
+/// timings. Shared compiles overlap the rustc-only background hash of source +
+/// externs with the compiler (issue #532), then join it before releasing shared
+/// admission. Exclusive compiles finish that work before spawning the compiler
+/// (issue #1555). Both paths return the ready map in `pre_hashed`.
 pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExecResult {
     let CompileExecRequest {
         state_arc,
@@ -275,7 +276,9 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     // translation unit or known amalgamated Rust release crate drains those
     // readers and runs alone. The shared helper acquires the bounded FIFO
     // compile slot first and the resource gate second, then both remain held
-    // across overlapping input hashing and the compiler child.
+    // through input hashing and the compiler child. Shared compiles overlap
+    // those phases; exclusive compiles serialize them so the compiler truly
+    // has exclusive access to the build system.
     let built_in_exclusive =
         crate::daemon::server::compile_resource_gate::requires_exclusive_access(
             compilation.family,
@@ -296,7 +299,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
             });
         }
     };
-    let (_compiler_admission, available_before) =
+    let (compiler_admission, available_before) =
         crate::daemon::server::compile_resource_gate::acquire_compiler_admission(state, exclusive)
             .await;
     if exclusive {
@@ -307,40 +310,35 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         );
     }
 
-    // Issue #532: kick off hashing of pre-known inputs (source +
-    // rustc_extern_paths) on a blocking thread, in parallel with the
-    // rustc spawn. The 50-rlib externs of a workspace link dominate
-    // hash_all_ns (~64 ms on a 4-core CI runner); overlapping them with
-    // the ~38 ms rustc exec hides most of that cost. Late-arriving
-    // include paths (from rustc's dep-info) are hashed post-compile and
-    // merged with the pre-hash result. Skip for non-rustc compilers —
-    // they don't have a known-ahead extern list, and their cold hash_all
-    // is small anyway.
-    let pre_hash_task: Option<tokio::task::JoinHandle<HashMap<NormalizedPath, ContentHash>>> =
-        if is_rustc && !rustc_extern_paths.is_empty() {
-            let pre_state = Arc::clone(state_arc);
-            let pre_source = source_path.clone();
-            let pre_externs: Vec<NormalizedPath> = rustc_extern_paths.to_vec();
-            let pre_clock = snap_clock;
-            Some(tokio::task::spawn_blocking(move || {
-                use rayon::prelude::*;
-                let all_paths: Vec<&NormalizedPath> = std::iter::once(&pre_source)
-                    .chain(pre_externs.iter())
-                    .collect();
-                all_paths
-                    .par_iter()
-                    .filter_map(|path| {
-                        let hash_path = resolve_pch_source(path, &pre_state.pch_source_map)
-                            .unwrap_or_else(|| (*path).clone());
-                        hash_file(&pre_state.cache_system, &hash_path, pre_clock)
-                            .ok()
-                            .map(|h| ((*path).clone(), h))
-                    })
-                    .collect()
-            }))
-        } else {
-            None
-        };
+    // Issue #532: hash pre-known rustc inputs (source + externs) on a blocking
+    // thread. Shared compiles retain the fast overlap with the compiler. Issue
+    // #1555: exclusive compiles await this work while holding the exclusive
+    // admission guard, before spawning the memory-heavy compiler child.
+    let (pre_hash_task, pre_hashed) = if is_rustc && !rustc_extern_paths.is_empty() {
+        let pre_state = Arc::clone(state_arc);
+        let pre_source = source_path.clone();
+        let pre_externs: Vec<NormalizedPath> = rustc_extern_paths.to_vec();
+        let pre_clock = snap_clock;
+        schedule_pre_hash(exclusive, move || {
+            use rayon::prelude::*;
+            let all_paths: Vec<&NormalizedPath> = std::iter::once(&pre_source)
+                .chain(pre_externs.iter())
+                .collect();
+            all_paths
+                .par_iter()
+                .filter_map(|path| {
+                    let hash_path = resolve_pch_source(path, &pre_state.pch_source_map)
+                        .unwrap_or_else(|| (*path).clone());
+                    hash_file(&pre_state.cache_system, &hash_path, pre_clock)
+                        .ok()
+                        .map(|h| ((*path).clone(), h))
+                })
+                .collect()
+        })
+        .await
+    } else {
+        (None, None)
+    };
 
     // Issue #813 / #816: acquire a compile-concurrency permit before
     // spawning the compiler. The semaphore (when present — None means
@@ -492,6 +490,13 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let stderr = Arc::new(stderr_bytes);
     let post_exec_ns = t_post_exec.elapsed().as_nanos() as u64;
 
+    // Shared compiles overlap pre-hashing with rustc, but must join it before
+    // releasing shared admission. Otherwise a queued exclusive compiler can
+    // acquire the write side while this request's Rayon workers are still
+    // consuming CPU and memory. Exclusive compiles already carry a ready map.
+    let pre_hashed = finish_pre_hash(pre_hash_task, pre_hashed).await;
+    drop(compiler_admission);
+
     // Drop the response-file guard now that the compiler has exited. The
     // pre-split function held the guard until end-of-function via `let
     // _rsp_guard = ...`; keeping it bound to a local in this helper does
@@ -505,7 +510,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         stderr,
         depfile_strategy,
         dependency_scan,
-        pre_hash_task,
+        pre_hashed,
         compiler_priority_decision,
         pre_exec_ns,
         break_outputs_ns,
@@ -515,6 +520,32 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         post_exec_ns,
         staged_plan,
     })
+}
+
+async fn schedule_pre_hash<T, F>(
+    exclusive: bool,
+    work: F,
+) -> (Option<tokio::task::JoinHandle<T>>, Option<T>)
+where
+    T: Default + Send + 'static,
+    F: FnOnce() -> T + Send + 'static,
+{
+    let task = tokio::task::spawn_blocking(work);
+    if exclusive {
+        (None, Some(task.await.unwrap_or_default()))
+    } else {
+        (Some(task), None)
+    }
+}
+
+async fn finish_pre_hash<T>(task: Option<tokio::task::JoinHandle<T>>, ready: Option<T>) -> Option<T>
+where
+    T: Default + Send + 'static,
+{
+    match task {
+        Some(task) => Some(task.await.unwrap_or_default()),
+        None => ready,
+    }
 }
 
 fn header_trace_path(depfile: &NormalizedPath) -> NormalizedPath {
@@ -651,9 +682,9 @@ fn should_inject_header_trace_for_source(
 #[cfg(test)]
 mod tests {
     use super::{
-        header_trace_is_supported, prepare_private_clang_header_trace, should_inject_header_trace,
-        should_inject_header_trace_for_source, use_full_clang_depfile_for_cpp,
-        use_private_clang_header_trace,
+        finish_pre_hash, header_trace_is_supported, prepare_private_clang_header_trace,
+        schedule_pre_hash, should_inject_header_trace, should_inject_header_trace_for_source,
+        use_full_clang_depfile_for_cpp, use_private_clang_header_trace,
     };
     use crate::compiler::CompilerFamily;
     use crate::daemon::server::dependency_policy::DependencyDiscoveryMode;
@@ -661,6 +692,28 @@ mod tests {
 
     fn args(values: &[&str]) -> Vec<String> {
         values.iter().map(|value| (*value).to_string()).collect()
+    }
+
+    #[tokio::test]
+    async fn exclusive_pre_hash_finishes_before_the_compiler_phase() {
+        let (task, ready) = schedule_pre_hash(true, || 42_u32).await;
+
+        assert!(
+            task.is_none(),
+            "exclusive hashing must not overlap the compiler"
+        );
+        assert_eq!(ready, Some(42));
+    }
+
+    #[tokio::test]
+    async fn shared_pre_hash_retains_compiler_overlap() {
+        let (task, ready) = schedule_pre_hash(false, || 42_u32).await;
+
+        assert!(
+            ready.is_none(),
+            "shared hashing must stay on the overlap path"
+        );
+        assert_eq!(finish_pre_hash(task, ready).await, Some(42));
     }
 
     #[test]

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -440,10 +440,9 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
     // Issue #401 plumbing: the `hash_map` extracted here is fed back
     // into the cc/cpp miss path's `StoreOutcomeRequest.pre_hashed` so
     // the post-compile parallel hash skips files we already hashed
-    // here. The rustc miss path uses `pre_hash_task` (a background
-    // join handle) instead and ignores `pre_hashed`. The binding is
-    // marked `mut` so the rustc compat-check branch below can take it
-    // by `mem::take` without forcing a clone.
+    // here. The rustc miss path receives its ready pre-hash map from
+    // `run_compile_exec`. The binding is marked `mut` so the rustc
+    // compat-check branch below can take it by `mem::take` without a clone.
     let HashVerifyOutcome {
         mut hash_map,
         hash_source_ns,
@@ -836,7 +835,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         stderr,
         depfile_strategy,
         dependency_scan,
-        pre_hash_task,
+        pre_hashed: exec_pre_hashed,
         compiler_priority_decision,
         pre_exec_ns,
         break_outputs_ns,
@@ -949,15 +948,16 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             exit_code,
             depfile_strategy,
             compiler_dependency_scan: dependency_scan,
-            pre_hash_task,
             // Issue #401: hand the cc/cpp miss path the hashes already
             // computed in `hash_and_verify` so `store_outcome.rs` skips
             // re-hashing the same headers in its parallel `t_hash` phase.
-            // For rustc the same hashes arrive via `pre_hash_task` and
-            // `pre_hashed` is left `None`. If we got here via cold context
-            // or fell back to a direct compile, `hash_map` is empty and
-            // the store path will hash everything as before.
-            pre_hashed: if is_rustc || hash_map.is_empty() {
+            // For rustc the same hashes arrive from `run_compile_exec` after
+            // shared admission has covered the entire background task. If we
+            // got here via cold context or fell back to a direct compile,
+            // `hash_map` is empty and the store path hashes everything.
+            pre_hashed: if is_rustc {
+                exec_pre_hashed
+            } else if hash_map.is_empty() {
                 None
             } else {
                 Some(hash_map)

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -45,14 +45,13 @@ pub(super) struct StoreOutcomeRequest<'a> {
     pub(super) exit_code: i32,
     pub(super) depfile_strategy: DepfileStrategy,
     pub(super) compiler_dependency_scan: Option<crate::depgraph::ScanResult>,
-    pub(super) pre_hash_task: Option<tokio::task::JoinHandle<HashMap<NormalizedPath, ContentHash>>>,
     /// Issue #401: pre-compile hashes already produced by `hash_and_verify`
     /// on the cc/cpp miss path. `None` means the pre-compile hash phase did
     /// not run (e.g. cold context, source-hash fallback) — fall back to
     /// hashing everything as before. When `Some`, the same `(path, hash)`
     /// pairs are seeded into the post-compile `hash_map` so the parallel
-    /// rayon hash skips files already covered. The rustc path uses
-    /// `pre_hash_task` (a `JoinHandle`) instead and is unaffected.
+    /// rayon hash skips files already covered. Rustc pre-hashing is joined by
+    /// the exec phase before it releases compiler admission.
     pub(super) pre_hashed: Option<HashMap<NormalizedPath, ContentHash>>,
     pub(super) compiler_priority_decision: crate::daemon::process::CompilePriorityDecision,
     pub(super) compile_start: std::time::Instant,
@@ -163,7 +162,6 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         exit_code,
         depfile_strategy,
         compiler_dependency_scan,
-        pre_hash_task,
         pre_hashed,
         compiler_priority_decision,
         compile_start,
@@ -414,10 +412,9 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     // ── Phase: hash all files (parallel) ─────────────────────────
     // Hash source + resolved headers + force-includes + rustc externs
     // using rayon parallel iteration. Issue #532: for rustc, the
-    // source + extern paths were already kicked off pre-compile via
-    // `pre_hash_task`; join here and then only hash the late-arriving
-    // includes (scan_result.resolved + force_includes), which are
-    // typically empty for workspace link.
+    // source + extern paths were already hashed by the exec phase; only hash
+    // the late-arriving includes (scan_result.resolved + force_includes),
+    // which are typically empty for a workspace link.
     //
     // Issue #401: for cc/cpp, the miss path already hashed source +
     // the depgraph's stored include set in `hash_and_verify`. Seed the
@@ -425,10 +422,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     // below skips files already present, instead of re-hashing every
     // header from scratch.
     let t_hash = std::time::Instant::now();
-    let mut hash_map: HashMap<NormalizedPath, ContentHash> = match pre_hash_task {
-        Some(task) => task.await.unwrap_or_default(),
-        None => pre_hashed.unwrap_or_default(),
-    };
+    let mut hash_map: HashMap<NormalizedPath, ContentHash> = pre_hashed.unwrap_or_default();
     let pre_hashed_count = hash_map.len();
     // #955: run the parallel hash under block_in_place so a large extern
     // set (the whole workspace, for a consolidated crate) doesn't park the
@@ -437,8 +431,8 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
     crate::daemon::process::run_cpu_blocking(|| {
         use rayon::prelude::*;
         // Build the post-compile path list. When the pre-hash phase
-        // populated `hash_map` (either rustc's `pre_hash_task` or the
-        // cc/cpp `pre_hashed` seed from `hash_and_verify`), skip paths
+        // populated `hash_map` (either rustc's exec-phase map or the cc/cpp
+        // `pre_hashed` seed from `hash_and_verify`), skip paths
         // already covered. Otherwise hash everything as before.
         let post_paths: Vec<&NormalizedPath> = if pre_hashed_count > 0 {
             std::iter::once(source_path)

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,11 @@
+# #1555 exclusive compiler admission includes pre-hashing
+
+- [x] Trace soldr CI's signal-terminated exclusive `soldr_cli --test` compile to zccache's post-admission Rayon pre-hash overlap.
+- [x] RED: deterministically prove exclusive pre-hash work completes before the compiler phase while shared work retains overlap.
+- [x] GREEN: await pre-hashing for exclusive units and pass its ready hashes into the existing store outcome without adding a global job cap.
+- [ ] Run focused tests, formatter, clippy/check, and the sanctioned performance matrix.
+- [ ] Review, push, merge, publish a patch release, then update Soldr's exact pin and release assets.
+
 # soldr#3031 preserve compiler termination signals
 
 - [x] Read the embedded-service, journal, protocol, and portability contracts.


### PR DESCRIPTION
Closes #1555.

Coordinated with zackees/soldr#3024 and zackees/soldr#3035.

## What changed

- Exclusive Rust units now complete source/extern pre-hashing after acquiring exclusive compiler admission and before spawning rustc.
- Shared Rust units retain pre-hash/compiler overlap for throughput.
- Shared admission remains held until the overlapping pre-hash task joins, preventing a queued exclusive unit from overlapping leftover Rayon work.
- Ready hashes flow into the existing store path; no global Cargo, Soldr, or compiler job cap is added.

## Validation

- RED regression test proved the missing exclusive sequencing.
- Two focused pre-hash tests pass.
- `cargo clippy -p zccache-daemon-core --features test-support --all-targets -- -D warnings` passes through Soldr.
- daemon-core suite: 828 pass, 28 ignored; one unrelated filesystem timestamp fixture fails on the 2026 host clock.
- repository suite progressed through native/cache suites, then an unrelated macOS `cli-crash-trigger sigsegv` fixture hung.
- Required local Linux perf matrix was attempted from this clean commit but Docker Debian bookworm rejected official apt signatures before building the benchmark image; no matrix cell ran. Upstream CI should supply the clean Linux result.