### PR TITLE
fix(admission): cover post-compiler cache work

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
@@ -4,7 +4,10 @@
 //! Published Rust crates can have the same shape without a large root file:
 //! zccache's release crate folds its internal workspace into one rustc unit.
 //! Ordinary compiles take shared admission; either kind of amalgamation takes
-//! exclusive admission immediately before the compiler child is spawned.
+//! exclusive admission immediately before the compiler child is spawned. The
+//! resource permit remains live through cache hashing/publication after the
+//! bounded compiler slot is returned, so post-compiler work cannot overlap a
+//! queued exclusive unit.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -112,6 +115,19 @@ pub(super) enum CompileResourcePermit {
 pub(super) struct CompilerAdmission {
     _resource: CompileResourcePermit,
     _compile: super::compile_progress::CompileGateGuard,
+}
+
+impl CompilerAdmission {
+    /// Return scarce compiler capacity while preserving build-wide resource
+    /// ownership for the request's hashing and publication phases.
+    pub(super) fn release_compiler_slot(self) -> CompileResourcePermit {
+        let Self {
+            _resource: resource,
+            _compile: compile,
+        } = self;
+        drop(compile);
+        resource
+    }
 }
 
 impl CompileResourceGate {
@@ -550,6 +566,45 @@ mod tests {
             .expect("ordinary compiles must not serialize");
     }
 
+    #[tokio::test]
+    async fn compiler_slot_can_be_released_while_resource_admission_remains_live() {
+        use std::time::Duration;
+
+        let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+        let queue = Arc::new(crate::daemon::server::compile_progress::CompileQueueGauge::default());
+        let resource_gate = CompileResourceGate::default();
+        let (compile, _) =
+            crate::daemon::server::compile_progress::acquire_compile_gate(Some(&semaphore), &queue)
+                .await;
+        let admission = CompilerAdmission {
+            _resource: resource_gate.acquire(false).await,
+            _compile: compile,
+        };
+
+        assert_eq!(semaphore.available_permits(), 0);
+        let resource = admission.release_compiler_slot();
+        assert_eq!(
+            semaphore.available_permits(),
+            1,
+            "post-compiler work must not consume a compiler-capacity slot"
+        );
+
+        let exclusive_gate = resource_gate.clone();
+        let mut exclusive = tokio::spawn(async move { exclusive_gate.acquire(true).await });
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), &mut exclusive)
+                .await
+                .is_err(),
+            "exclusive compiler must wait for shared post-compiler work"
+        );
+
+        drop(resource);
+        tokio::time::timeout(Duration::from_secs(1), exclusive)
+            .await
+            .expect("exclusive compiler should acquire after post-processing")
+            .expect("exclusive task");
+    }
+
     #[test]
     fn direct_rust_and_c_invocations_use_the_same_classifier() {
         assert!(requires_exclusive_access_from_args(
@@ -638,6 +693,10 @@ mod tests {
             assert!(
                 source.contains("acquire_compiler_admission("),
                 "{name} compiler path bypasses shared admission"
+            );
+            assert!(
+                source.contains("release_compiler_slot()"),
+                "{name} compiler path does not split compiler capacity from post-compiler resource ownership"
             );
         }
     }

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store.rs
@@ -38,6 +38,8 @@ pub(super) struct MissArtifactStoreRequest<'a> {
     pub(super) compile_start: Instant,
     pub(super) synchronous_persist: bool,
     pub(super) publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
+    pub(super) resource_admission:
+        crate::daemon::server::compile_resource_gate::CompileResourcePermit,
 }
 
 #[derive(Default)]
@@ -83,6 +85,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
         compile_start,
         synchronous_persist,
         publication_guard,
+        resource_admission,
     } = request;
     let state = state_arc.as_ref();
     let t_store = Instant::now();
@@ -146,6 +149,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
                 synchronous_persist,
                 staged_persist_plan,
                 publication_guard,
+                resource_admission,
             );
         } else {
             store_single_output(
@@ -165,6 +169,7 @@ pub(super) fn store_miss_artifact(request: MissArtifactStoreRequest<'_>) -> Miss
                 t_artifact_build,
                 synchronous_persist,
                 publication_guard,
+                resource_admission,
             );
         }
     }
@@ -317,6 +322,7 @@ fn store_rustc_outputs(
     synchronous_persist: bool,
     staged_persist_plan: Option<StagedCompilePlan>,
     publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
+    resource_admission: crate::daemon::server::compile_resource_gate::CompileResourcePermit,
 ) {
     let state = state_arc.as_ref();
     let t_artifact_meta_build = Instant::now();
@@ -407,6 +413,7 @@ fn store_rustc_outputs(
                 .expect("persist_semaphore is owned by ServerState and never closed");
             let published = tokio::task::spawn_blocking(move || {
                 let _publication_guard = publication_guard;
+                let _resource_admission = resource_admission;
                 let _staged_plan = plan_for_publish;
                 let snapshot =
                     persist_artifact_paths_with_stats(&artifact_dir, &key_hex, &source_paths)?;
@@ -593,6 +600,7 @@ fn store_rustc_outputs(
     });
     stats.artifact_insert_stats_ns = t_artifact_insert_stats.elapsed().as_nanos() as u64;
     drop(publication_guard);
+    drop(resource_admission);
 }
 
 fn remove_provisional_artifact(state: &SharedState, key_hex: &str, provisional: &CachedArtifact) {
@@ -689,6 +697,7 @@ fn store_single_output(
     t_artifact_build: Instant,
     synchronous_persist: bool,
     publication_guard: tokio::sync::OwnedRwLockReadGuard<()>,
+    resource_admission: crate::daemon::server::compile_resource_gate::CompileResourcePermit,
 ) {
     let state = state_arc.as_ref();
     // Issue #643: stash the user's depfile as a second output so cache
@@ -833,6 +842,7 @@ fn store_single_output(
         });
         stats.artifact_insert_stats_ns = t_persist_enqueue.elapsed().as_nanos() as u64;
         drop(publication_guard);
+        drop(resource_admission);
         return;
     }
 
@@ -864,6 +874,7 @@ fn store_single_output(
         let written = tokio::task::spawn_blocking(move || {
             let _guard = guard;
             let _publication_guard = publication_guard;
+            let _resource_admission = resource_admission;
             let _user_depfile_persist_temp = user_depfile_persist_temp;
             // Issue #728: `gap_ms` = wall-clock between
             // "linker-success-recorded" (immediately before this spawn was

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store_tests.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/miss_store_tests.rs
@@ -6,6 +6,7 @@ use super::{
     MissArtifactStoreStats, PersistOutcome, MAX_STAGED_PUBLICATION_ERROR_CHARS,
 };
 use crate::core::NormalizedPath;
+use crate::daemon::server::compile_resource_gate::CompileResourceGate;
 use crate::daemon::server::*;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -67,6 +68,8 @@ async fn perf_staged_rust_hit_uses_provisional_payload_before_durable_publicatio
     let source_path: NormalizedPath = work.path().join("lib.rs").into();
     let mut stats = MissArtifactStoreStats::default();
     let publication_guard = begin_artifact_publication(&state).await.unwrap();
+    let resource_gate = CompileResourceGate::default();
+    let resource_admission = resource_gate.acquire(false).await;
 
     store_rustc_outputs(
         &state,
@@ -84,6 +87,15 @@ async fn perf_staged_rust_hit_uses_provisional_payload_before_durable_publicatio
         false,
         Some(plan),
         publication_guard,
+        resource_admission,
+    );
+    let exclusive_gate = resource_gate.clone();
+    let mut exclusive = tokio::spawn(async move { exclusive_gate.acquire(true).await });
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut exclusive)
+            .await
+            .is_err(),
+        "exclusive compiler must wait while detached shared publication is blocked"
     );
     assert!(
         staged.is_file(),
@@ -148,6 +160,10 @@ async fn perf_staged_rust_hit_uses_provisional_payload_before_durable_publicatio
         pending_writes::await_all(&state.pending_cache_writes, Duration::from_secs(10)).await,
         "detached publisher did not complete after its permit was released"
     );
+    tokio::time::timeout(Duration::from_secs(1), exclusive)
+        .await
+        .expect("exclusive compiler should acquire after detached publication")
+        .expect("exclusive task");
 }
 
 #[tokio::test]

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -41,6 +41,8 @@ pub(super) struct CompileExecOutcome {
     pub(super) compiler_prep_ns: u64,
     pub(super) post_exec_ns: u64,
     pub(super) staged_plan: Option<StagedCompilePlan>,
+    pub(super) resource_admission:
+        crate::daemon::server::compile_resource_gate::CompileResourcePermit,
 }
 
 pub(super) enum CompileExecResult {
@@ -491,11 +493,13 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
     let post_exec_ns = t_post_exec.elapsed().as_nanos() as u64;
 
     // Shared compiles overlap pre-hashing with rustc, but must join it before
-    // releasing shared admission. Otherwise a queued exclusive compiler can
-    // acquire the write side while this request's Rayon workers are still
-    // consuming CPU and memory. Exclusive compiles already carry a ready map.
+    // returning the bounded compiler slot. Resource admission stays live in
+    // the returned outcome through cache hashing/publication. Otherwise a
+    // queued exclusive compiler can acquire the write side while this
+    // request's Rayon workers are still consuming CPU and memory. Exclusive
+    // compiles already carry a ready map.
     let pre_hashed = finish_pre_hash(pre_hash_task, pre_hashed).await;
-    drop(compiler_admission);
+    let resource_admission = compiler_admission.release_compiler_slot();
 
     // Drop the response-file guard now that the compiler has exited. The
     // pre-split function held the guard until end-of-function via `let
@@ -519,6 +523,7 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
         compiler_prep_ns,
         post_exec_ns,
         staged_plan,
+        resource_admission,
     })
 }
 

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/mod.rs
@@ -844,6 +844,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
         compiler_prep_ns,
         post_exec_ns,
         staged_plan,
+        resource_admission: _resource_admission,
     } = match exec_result {
         CompileExecResult::Ok(outcome) => outcome,
         CompileExecResult::Error(resp) => return resp,
@@ -978,6 +979,7 @@ pub(super) async fn handle_compile_request(req: CompileRequest<'_>) -> Response 
             hash_headers_ns,
             depgraph_check_ns,
             break_outputs_ns,
+            resource_admission: _resource_admission,
         })
         .await
         {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/store_outcome.rs
@@ -70,6 +70,8 @@ pub(super) struct StoreOutcomeRequest<'a> {
     pub(super) hash_headers_ns: u64,
     pub(super) depgraph_check_ns: u64,
     pub(super) break_outputs_ns: u64,
+    pub(super) resource_admission:
+        crate::daemon::server::compile_resource_gate::CompileResourcePermit,
 }
 
 enum CompileOutputCollection {
@@ -179,6 +181,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
         hash_headers_ns,
         depgraph_check_ns,
         break_outputs_ns,
+        resource_admission,
     } = req;
 
     let state = state_arc.as_ref();
@@ -634,6 +637,7 @@ pub(super) async fn store_successful_compile(req: StoreOutcomeRequest<'_>) -> Op
                 compile_start,
                 synchronous_persist,
                 publication_guard,
+                resource_admission,
             })
         })
     } else {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
@@ -164,7 +164,7 @@ pub(super) async fn run_compiler_direct_with_family(
             };
         }
     };
-    let (_compiler_admission, _) =
+    let (compiler_admission, _) =
         super::compile_resource_gate::acquire_compiler_admission(state, exclusive).await;
     if exclusive {
         tracing::info!(
@@ -199,6 +199,8 @@ pub(super) async fn run_compiler_direct_with_family(
             None,
         )
     };
+
+    let _resource_admission = compiler_admission.release_compiler_slot();
 
     match result {
         Ok(mut output) => {

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -784,7 +784,7 @@ pub(super) async fn handle_compile_multi(
     let result =
         super::super::process::tokio_command_output_with_priority(&mut cmd, compiler_priority)
             .await;
-    drop(compiler_admission);
+    let _resource_admission = compiler_admission.release_compiler_slot();
 
     let output = match result {
         Ok(o) => o,

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -56,6 +56,7 @@ struct StagedCompilerOutput {
     unit_index: usize,
     output: std::process::Output,
     elapsed_ns: u64,
+    resource_admission: crate::daemon::server::compile_resource_gate::CompileResourcePermit,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -237,7 +238,7 @@ pub(super) async fn try_handle_staged_misses(
         // clients' heartbeats report.
         let unit_index = miss.unit_index;
         compiler_set.spawn(async move {
-            let (_compiler_admission, available_before) =
+            let (compiler_admission, available_before) =
                 crate::daemon::server::compile_resource_gate::acquire_compiler_admission(
                     &admission_state,
                     exclusive,
@@ -269,11 +270,13 @@ pub(super) async fn try_handle_staged_misses(
             let output = output.map_err(|error| {
                 format!("failed to run staged multi-source compiler: {error}")
             })?;
+            let resource_admission = compiler_admission.release_compiler_slot();
             drop(rsp_guard);
             Ok::<_, String>(StagedCompilerOutput {
                 unit_index,
                 output,
                 elapsed_ns,
+                resource_admission,
             })
         });
     }
@@ -302,15 +305,20 @@ pub(super) async fn try_handle_staged_misses(
         return Some(Response::Error { message });
     }
 
+    let mut _resource_admissions = Vec::with_capacity(misses.len());
     for miss in &mut misses {
         let Some(StagedCompilerOutput {
-            output, elapsed_ns, ..
+            output,
+            elapsed_ns,
+            resource_admission,
+            ..
         }) = compiler_outputs[miss.unit_index].take()
         else {
             return Some(Response::Error {
                 message: "staged multi-source compiler produced no result".to_string(),
             });
         };
+        _resource_admissions.push(resource_admission);
         state
             .profiler
             .staged


### PR DESCRIPTION
## Summary

- split bounded compiler capacity from shared/exclusive resource ownership after the compiler child exits
- carry resource admission through dependency hashing, artifact storage, and staged multi-source publication
- transfer the permit into detached persistence tasks so an exclusive compiler cannot overlap their retained data/Rayon/disk work
- preserve throughput by returning the compiler semaphore slot immediately

## RED evidence

Soldr CI run 33468339980 on zccache 1.13.18 correctly classified `soldr_cli --test` as exclusive, then terminated it with SIGTERM at a 7.60 GiB peak while cgroup OOM counters stayed zero. Inspection showed compiler admission dropped before cache hashing/publication, and detached staged publication could outlive the request entirely.

The focused detached-publisher regression blocks persistence after the compiler phase and queues an exclusive writer. Against the 1.13.18 ownership shape the writer acquires early; with this change it remains blocked until durable publication completes.

## GREEN evidence

- `compiler_slot_can_be_released_while_resource_admission_remains_live`: passes
- `perf_staged_rust_hit_uses_provisional_payload_before_durable_publication`: passes with exclusive-writer assertion
- daemon-core Clippy, all targets, test-support, `-D warnings`: passes
- daemon-core suite: 829 passed, 28 ignored; one unrelated existing filesystem timestamp fixture fails because it expects epoch `1000000000` on the current 2026-clock host
- rustfmt and `git diff --check`: pass

Closes #1558
