### PR TITLE
release: prepare 1.13.20

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "blake3",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "blake3",
@@ -4320,14 +4320,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "clang",
  "serde_json",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "blake3",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "blake3",
  "futures",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "bytes",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "filetime",
  "fs2",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint-py"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "reqwest",
  "serde",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4520,7 +4520,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "blake3",
  "bytes",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-platform"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "crash-handler",
  "interprocess",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "bytes",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "tempfile",
  "zccache-audit",
@@ -4589,7 +4589,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "globset",
  "jwalk",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher-py"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.19"
+version = "1.13.20"
 edition = "2021"
 rust-version = "1.95.0"
 license = "AGPL-3.0-only"


### PR DESCRIPTION
Publishes the atomic staged-materialization fix from #1563 / #1562 for Soldr CI.

Validation: `ZCCACHE_DISABLE=1 soldr cargo check --workspace --locked`.

The autonomous release workflow will create the tag and publish all artifacts after merge.