### PR TITLE
test: unify cache-dir environment lock

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/depgraph_load.rs
+++ b/crates/zccache-daemon-core/src/daemon/depgraph_load.rs
@@ -230,7 +230,20 @@ fn emit_reset_event(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::daemon::server::tests::CacheDirEnvGuard;
     use crate::depgraph::DEPGRAPH_VERSION;
+
+    /// The typed cache-dir guard used by every depgraph fixture load. Keeping
+    /// this seam typed to the canonical owner prevents a test-local guard from
+    /// silently reintroducing a second process-environment lock.
+    fn fixture_cache_dir_guard(root: &Path) -> CacheDirEnvGuard {
+        CacheDirEnvGuard::set(root)
+    }
+
+    /// Nonblocking companion for the lock-sharing regression below.
+    fn try_fixture_cache_dir_guard(root: &Path) -> Option<CacheDirEnvGuard> {
+        CacheDirEnvGuard::try_set(root)
+    }
 
     /// Drives the real call site (unlike the earlier hand-rolled payload
     /// tests this replaces): writes a version-skewed snapshot, runs
@@ -257,7 +270,7 @@ mod tests {
         /// `write_event` resolves the cache root from the process environment;
         /// point it at this fixture for the duration of one load.
         fn load(&self) -> (StartupLoad, serde_json::Value) {
-            let _guard = CacheRootEnv::set(&self.cache_root);
+            let _guard = fixture_cache_dir_guard(&self.cache_root);
             let load = load_for_startup(&self.snapshot);
             // Resolve the log exactly the way production's `write_event` does,
             // so the test cannot pass by reading a path the daemon never uses.
@@ -286,34 +299,6 @@ mod tests {
                 let mut bytes = std::fs::read(&self.snapshot).unwrap();
                 bytes[4..8].copy_from_slice(&version.to_le_bytes());
                 std::fs::write(&self.snapshot, &bytes).unwrap();
-            }
-        }
-    }
-
-    struct CacheRootEnv {
-        _lock: std::sync::MutexGuard<'static, ()>,
-        previous: Option<std::ffi::OsString>,
-    }
-
-    static CACHE_ROOT_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    impl CacheRootEnv {
-        fn set(root: &Path) -> Self {
-            let lock = CACHE_ROOT_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-            let previous = std::env::var_os("ZCCACHE_CACHE_DIR");
-            std::env::set_var("ZCCACHE_CACHE_DIR", root);
-            Self {
-                _lock: lock,
-                previous,
-            }
-        }
-    }
-
-    impl Drop for CacheRootEnv {
-        fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => std::env::set_var("ZCCACHE_CACHE_DIR", value),
-                None => std::env::remove_var("ZCCACHE_CACHE_DIR"),
             }
         }
     }
@@ -469,12 +454,41 @@ mod tests {
     #[test]
     fn a_missing_snapshot_is_a_plain_cold_start_with_no_event() {
         let fixture = Fixture::new();
-        let _guard = CacheRootEnv::set(&fixture.cache_root);
+        let _guard = fixture_cache_dir_guard(&fixture.cache_root);
         let load = load_for_startup(&fixture.snapshot);
         assert!(load.graph.is_none());
         assert!(
             load.warning.is_none(),
             "a first run is not a degraded load and must not warn"
         );
+    }
+
+    #[test]
+    fn fixture_guard_reports_canonical_cache_dir_contention() {
+        let fixture = Fixture::new();
+        let held_temp = tempfile::tempdir().unwrap();
+        let held_root = held_temp.path().join("held-cache-root");
+        let held = CacheDirEnvGuard::set(&held_root);
+
+        assert!(
+            try_fixture_cache_dir_guard(&fixture.cache_root).is_none(),
+            "a depgraph fixture must contend on the canonical guard instead \
+             of acquiring a private cache-dir lock"
+        );
+        assert_eq!(
+            std::env::var_os(crate::core::config::CACHE_DIR_ENV).as_deref(),
+            Some(held_root.as_os_str()),
+            "a contended fixture must not mutate the canonical guard owner's \
+             cache root"
+        );
+
+        drop(held);
+        let fixture_guard = fixture_cache_dir_guard(&fixture.cache_root);
+        assert_eq!(
+            std::env::var_os(crate::core::config::CACHE_DIR_ENV).as_deref(),
+            Some(fixture.cache_root.as_os_str()),
+            "the fixture guard must install its own cache root after contention ends"
+        );
+        drop(fixture_guard);
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/server/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/mod.rs
@@ -236,4 +236,4 @@ use wal::*;
 use watch::*;
 
 #[cfg(test)]
-mod tests;
+pub(crate) mod tests;

--- a/crates/zccache-daemon-core/src/daemon/server/tests/README.md
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/README.md
@@ -7,7 +7,8 @@ PCH resolution, write-cached-output, post-link hook, server IPC end-to-end).
 `fs_matrix.rs` runs the same materialization contract against every available
 filesystem fixture and always prints executed/skipped rows with reasons.
 
-`mod.rs` declares the per-domain submodules and owns only the cross-module
-helpers (`CacheDirEnvGuard`). Per-domain helpers (fixture builders,
+`mod.rs` declares the per-domain submodules and owns the crate-wide canonical
+test guard for process-global cache-dir mutations (`CacheDirEnvGuard`).
+Per-domain helpers (fixture builders,
 `start_daemon`, jobserver-env constructors, `write_fake_linker`, etc.) live
 next to the tests that use them — no `common.rs` indirection.

--- a/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/tests/mod.rs
@@ -1,7 +1,7 @@
 //! Unit tests for `server/` submodules. Originally a single 2.3K-LOC
 //! `tests.rs`; split per domain so each file stays well under 1,000 LOC.
 //! Each module owns whatever fixture / helper code its tests use, except
-//! for the truly cross-module `CacheDirEnvGuard` defined below.
+//! for the crate-wide `CacheDirEnvGuard` defined below.
 
 use std::path::Path;
 
@@ -63,12 +63,11 @@ pub(super) fn bind_isolated_server_at(endpoint: &str, cache_root: &Path) -> supe
 }
 
 /// RAII guard that overrides `ZCCACHE_CACHE_DIR` for the duration of a
-/// single test, restoring the previous value on drop. Shared between
-/// `link_cache` (link side-effects test) and `server_ipc`
-/// (`cli_compile_unknown_uuid_is_idempotent`) — both need an isolated
-/// per-test cache dir so they don't clash with any production daemon
-/// writing the global index blob.
-pub(super) struct CacheDirEnvGuard {
+/// single test, restoring the previous value on drop. This is the one owner
+/// for process-global cache-dir test mutations across the daemon crate. It
+/// also clears the daemon namespace while installed and restores it on drop,
+/// so a fixture cannot inherit another test's daemon identity.
+pub(crate) struct CacheDirEnvGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
     previous_cache_dir: Option<std::ffi::OsString>,
     previous_namespace: Option<std::ffi::OsString>,
@@ -80,14 +79,30 @@ impl CacheDirEnvGuard {
     /// Serializes tests that read or mutate daemon process environment without
     /// changing any variables itself. Tests with explicit cache roots use
     /// this when they must remain immune to concurrent staged-policy changes.
-    pub(super) fn lock() -> std::sync::MutexGuard<'static, ()> {
+    pub(crate) fn lock() -> std::sync::MutexGuard<'static, ()> {
         CACHE_DIR_ENV_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
     }
 
-    pub(super) fn set(path: &Path) -> Self {
+    pub(crate) fn set(path: &Path) -> Self {
         let lock = Self::lock();
+        Self::set_with_lock(path, lock)
+    }
+
+    /// Attempts to override the cache directory without waiting for another
+    /// test that owns the process-global environment. Used by regression tests
+    /// to prove their fixture shares this guard rather than a private lock.
+    pub(crate) fn try_set(path: &Path) -> Option<Self> {
+        let lock = match CACHE_DIR_ENV_LOCK.try_lock() {
+            Ok(lock) => lock,
+            Err(std::sync::TryLockError::Poisoned(error)) => error.into_inner(),
+            Err(std::sync::TryLockError::WouldBlock) => return None,
+        };
+        Some(Self::set_with_lock(path, lock))
+    }
+
+    fn set_with_lock(path: &Path, lock: std::sync::MutexGuard<'static, ()>) -> Self {
         let previous_cache_dir = std::env::var_os(crate::core::config::CACHE_DIR_ENV);
         let previous_namespace = std::env::var_os(crate::core::config::DAEMON_NAMESPACE_ENV);
         std::env::set_var(crate::core::config::CACHE_DIR_ENV, path);


### PR DESCRIPTION
Closes #1560

Makes the existing server-test CacheDirEnvGuard the canonical owner for ZCCACHE_CACHE_DIR mutations across the daemon-core unit-test binary. The depgraph fixture now uses that guard instead of an unrelated mutex, preventing the lifecycle-log path race observed in CI.

The regression holds the canonical guard, proves a depgraph fixture cannot acquire or mutate through a private lock, then verifies normal acquisition after release. Validation also exercised the whole depgraph module in parallel and corrected two initial test-only reacquisition/snapshot races before publication.

Validation:
- soldr cargo test -p zccache-daemon-core --features test-support --lib daemon::depgraph_load::tests
- 6 passed
- soldr cargo fmt --all -- --check
- git diff --check
- Independent pre-push review: clean