### PR TITLE
feat(embedded): expose shared host-work permits

### DIFF
--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -59,6 +59,11 @@ pub struct ZccacheService {
     /// host token, this is always present so forced shutdown can abort work
     /// submitted through any cloned handle.
     force_cancellation: CancellationToken,
+    /// Fired when any shutdown begins so admission waiters do not outlive the
+    /// service. This is intentionally separate from `force_cancellation`:
+    /// graceful shutdown rejects queued work without aborting work already in
+    /// the daemon engine.
+    admission_shutdown: CancellationToken,
     /// Optional admission gate implementing `max_parallel_compiles`.
     compile_permits: Option<Arc<Semaphore>>,
     /// RAII handle for the optional host-in-flight counter registration
@@ -240,6 +245,18 @@ pub struct ServiceLimits {
     /// double-register case is debuggable. `None` keeps today's
     /// behavior — `Auto` consults only zccache's internal counter.
     pub host_in_flight: Option<Arc<std::sync::atomic::AtomicUsize>>,
+}
+
+/// Opaque RAII reservation for one unit of embedded host work.
+///
+/// Obtain this from [`ZccacheService::acquire_external_work_permit`] before
+/// starting host-owned compiler-adjacent work. It shares the exact admission
+/// capacity used by [`ZccacheService::compile`], and releases that capacity
+/// when dropped. When `ServiceLimits::max_parallel_compiles` is `None`, the
+/// guard is still usable but carries no semaphore reservation.
+#[must_use = "keep this permit alive while the admitted host work runs"]
+pub struct ExternalWorkPermit {
+    _permit: Option<tokio::sync::OwnedSemaphorePermit>,
 }
 
 /// Optional artifact-store limits for [`ZccacheService::start_with_disk_limits`].
@@ -927,6 +944,7 @@ impl ZccacheService {
         if self.shutdown.swap(true, Ordering::AcqRel) {
             return Err(EmbeddedError::ShutDown);
         }
+        self.admission_shutdown.cancel();
         if matches!(mode, ShutdownMode::Force) {
             self.force_cancellation.cancel();
         }

--- a/crates/zccache-daemon-core/src/embedded/contract_tests.rs
+++ b/crates/zccache-daemon-core/src/embedded/contract_tests.rs
@@ -1,10 +1,15 @@
 //! Issue #905 regression tests for the completed embedded host contract.
 
+use std::future::Future;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+use std::task::Poll;
+use std::time::Duration;
 
 use tempfile::TempDir;
-use tokio::sync::Semaphore;
+use tokio::sync::{oneshot, Notify, Semaphore};
+use tokio_util::sync::CancellationToken;
 
 use super::*;
 
@@ -26,6 +31,161 @@ fn config(temp: &TempDir, instance: &str, max_parallel_compiles: Option<usize>) 
         runtime: RuntimeHooks::default(),
         cancellation: None,
     }
+}
+
+/// Holds compile tasks after `compile_inner` has acquired its shared permit
+/// but before the daemon engine starts the compiler. The affected tests use a
+/// multi-thread runtime, so this synchronous event callback never blocks a
+/// current-thread Tokio runtime.
+struct CompileStartGate {
+    started: AtomicUsize,
+    started_notify: Notify,
+    state: Mutex<CompileStartGateState>,
+    release_notify: Condvar,
+}
+
+#[derive(Default)]
+struct CompileStartGateState {
+    armed: bool,
+    released: bool,
+}
+
+/// Releases a test gate even if an assertion unwinds before its normal
+/// release point, so a compiler task cannot strand a Tokio worker.
+#[must_use = "keep the guard alive until the gated compile has been released"]
+struct CompileStartGateRelease {
+    gate: Arc<CompileStartGate>,
+}
+
+impl Drop for CompileStartGateRelease {
+    fn drop(&mut self) {
+        self.gate.release();
+    }
+}
+
+impl CompileStartGate {
+    fn new() -> Self {
+        Self {
+            started: AtomicUsize::new(0),
+            started_notify: Notify::new(),
+            state: Mutex::new(CompileStartGateState::default()),
+            release_notify: Condvar::new(),
+        }
+    }
+
+    fn started(&self) -> usize {
+        self.started.load(Ordering::Acquire)
+    }
+
+    async fn wait_for_starts(&self, expected: usize) {
+        complete_within_gate_timeout(
+            async {
+                loop {
+                    let notified = self.started_notify.notified();
+                    if self.started() >= expected {
+                        return;
+                    }
+                    notified.await;
+                }
+            },
+            "COMPILE_STARTED event",
+        )
+        .await;
+    }
+
+    fn arm(self: &Arc<Self>) -> CompileStartGateRelease {
+        {
+            let mut state = self.state.lock().expect("compile gate lock");
+            state.armed = true;
+            state.released = false;
+        }
+        CompileStartGateRelease {
+            gate: Arc::clone(self),
+        }
+    }
+
+    fn release(&self) {
+        let mut state = self.state.lock().expect("compile gate lock");
+        if !state.released {
+            state.released = true;
+            self.release_notify.notify_all();
+        }
+    }
+}
+
+const COMPILE_GATE_TIMEOUT: Duration = Duration::from_secs(15);
+
+async fn complete_within_gate_timeout<F>(future: F, operation: &'static str) -> F::Output
+where
+    F: Future,
+{
+    tokio::time::timeout(COMPILE_GATE_TIMEOUT, future)
+        .await
+        .unwrap_or_else(|_| panic!("timed out waiting for {operation}"))
+}
+
+impl EmbeddedEventSink for CompileStartGate {
+    fn emit(&self, event: &AuditEvent) {
+        if event.event.0 != crate::audit::AuditEventName::COMPILE_STARTED {
+            return;
+        }
+        self.started.fetch_add(1, Ordering::Release);
+        self.started_notify.notify_waiters();
+        let mut state = self.state.lock().expect("compile gate lock");
+        if !state.armed {
+            return;
+        }
+        while !state.released {
+            state = self
+                .release_notify
+                .wait(state)
+                .expect("compile gate lock remains valid");
+        }
+    }
+}
+
+fn c_compile_request(
+    temp: &TempDir,
+    compiler: crate::core::NormalizedPath,
+    name: &str,
+) -> (CompileRequest, PathBuf) {
+    let source = temp.path().join(format!("{name}.c"));
+    let output = temp.path().join(format!("{name}.o"));
+    std::fs::write(&source, format!("int {name}(void) {{ return 1; }}\n"))
+        .expect("C source fixture");
+    (
+        CompileRequest {
+            audit: AuditContext::new(
+                crate::audit::AuditId::new(format!("{name}-run")).expect("run id"),
+                crate::audit::AuditId::new(format!("{name}-trace")).expect("trace id"),
+            ),
+            compiler,
+            args: vec![
+                "-c".into(),
+                source.to_string_lossy().into_owned(),
+                "-o".into(),
+                output.to_string_lossy().into_owned(),
+            ],
+            cwd: temp.path().into(),
+            env: Vec::new(),
+            stdin: Vec::new(),
+        },
+        output,
+    )
+}
+
+async fn assert_pending<F>(future: &mut std::pin::Pin<Box<F>>, message: &'static str)
+where
+    F: Future,
+{
+    std::future::poll_fn(|context| {
+        assert!(
+            matches!(future.as_mut().poll(context), Poll::Pending),
+            "{message}"
+        );
+        Poll::Ready(())
+    })
+    .await;
 }
 
 #[tokio::test]
@@ -53,35 +213,56 @@ async fn oversized_parallel_compile_limit_is_rejected_without_panicking() {
     );
 }
 
-#[tokio::test]
-async fn max_parallel_compiles_gates_compile_admission() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn external_work_blocks_compile_admission_at_capacity_one() {
+    let Some(compiler) = crate::test_support::find_clang() else {
+        return;
+    };
     let temp = TempDir::new().expect("temp cache root");
-    let service = ZccacheService::start(config(&temp, "compile-limit", Some(1)))
+    let gate = Arc::new(CompileStartGate::new());
+    let service = ZccacheService::start_with_event_sink(
+        config(&temp, "compile-limit", Some(1)),
+        gate.clone(),
+    )
+    .await
+    .expect("service start");
+    let external = service
+        .acquire_external_work_permit()
         .await
-        .expect("service start");
-
-    let first = service
-        .acquire_compile_permit()
-        .await
-        .expect("first admission")
-        .expect("configured limit returns a permit");
-    let queued_service = service.clone();
-    let mut queued = tokio::spawn(async move { queued_service.acquire_compile_permit().await });
+        .expect("external work admitted");
+    let (request, output) = c_compile_request(&temp, compiler, "external_before_compile");
+    let mut compile = Box::pin(service.compile(request));
+    assert_pending(
+        &mut compile,
+        "a real compile must wait while external work holds the only permit",
+    )
+    .await;
     assert!(
-        tokio::time::timeout(std::time::Duration::from_millis(50), &mut queued)
-            .await
-            .is_err(),
-        "a second compile must wait while the only permit is held"
+        gate.started() == 0 && !output.exists(),
+        "a queued real compile must not emit COMPILE_STARTED or create output"
     );
 
-    drop(first);
-    let second = tokio::time::timeout(std::time::Duration::from_secs(1), queued)
+    let _gate_release = gate.arm();
+    let gate_for_release = Arc::clone(&gate);
+    let output_before_release = output.clone();
+    let release = tokio::spawn(async move {
+        gate_for_release.wait_for_starts(1).await;
+        assert!(
+            !output_before_release.exists(),
+            "the compiler must remain held at COMPILE_STARTED"
+        );
+        gate_for_release.release();
+    });
+    drop(external);
+    let response =
+        complete_within_gate_timeout(compile, "compile after external work releases capacity")
+            .await
+            .expect("real compile succeeds after external work releases capacity");
+    assert_eq!(response.exit_code, 0);
+    complete_within_gate_timeout(release, "compile gate release")
         .await
-        .expect("queued compile admitted after release")
-        .expect("queued task joined")
-        .expect("second admission")
-        .expect("configured limit returns a permit");
-    drop(second);
+        .expect("compile gate released");
+    assert!(output.exists(), "real compile creates its requested output");
 
     service
         .shutdown(ShutdownMode::Graceful)
@@ -89,32 +270,240 @@ async fn max_parallel_compiles_gates_compile_admission() {
         .expect("shutdown");
 }
 
-#[tokio::test]
-async fn forced_shutdown_cancels_a_compile_waiting_for_admission() {
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn compile_admission_blocks_external_work_at_capacity_one() {
+    let Some(compiler) = crate::test_support::find_clang() else {
+        return;
+    };
     let temp = TempDir::new().expect("temp cache root");
-    let service = ZccacheService::start(config(&temp, "queued-force", Some(1)))
+    let gate = Arc::new(CompileStartGate::new());
+    let service = ZccacheService::start_with_event_sink(
+        config(&temp, "external-limit", Some(1)),
+        gate.clone(),
+    )
+    .await
+    .expect("service start");
+    let _gate_release = gate.arm();
+    let (request, output) = c_compile_request(&temp, compiler, "compile_before_external");
+    let compile_service = service.clone();
+    let compile = tokio::spawn(async move { compile_service.compile(request).await });
+    gate.wait_for_starts(1).await;
+    assert!(
+        !output.exists(),
+        "the real compiler must be held after its admission event"
+    );
+
+    let mut external = Box::pin(service.acquire_external_work_permit());
+    assert_pending(
+        &mut external,
+        "external work must wait while the real compile holds the only permit",
+    )
+    .await;
+    assert!(
+        gate.started() == 1,
+        "the queued external task must not let another compile admission through"
+    );
+
+    gate.release();
+    let response = complete_within_gate_timeout(compile, "held real compile")
+        .await
+        .expect("compile task joined")
+        .expect("real compile succeeds");
+    assert_eq!(response.exit_code, 0);
+    assert!(output.exists(), "real compile creates its requested output");
+    let external = complete_within_gate_timeout(external, "external work after compile completion")
+        .await
+        .expect("external work admitted after compile completion");
+    drop(external);
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("shutdown");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn compiler_and_external_work_share_the_combined_limit() {
+    let Some(compiler) = crate::test_support::find_clang() else {
+        return;
+    };
+    let temp = TempDir::new().expect("temp cache root");
+    let gate = Arc::new(CompileStartGate::new());
+    let service = ZccacheService::start_with_event_sink(
+        config(&temp, "combined-limit", Some(3)),
+        gate.clone(),
+    )
+    .await
+    .expect("service start");
+    let _gate_release = gate.arm();
+    let (first_request, first_output) = c_compile_request(&temp, compiler.clone(), "combined_one");
+    let (second_request, second_output) =
+        c_compile_request(&temp, compiler.clone(), "combined_two");
+    let (third_request, third_output) = c_compile_request(&temp, compiler, "combined_three");
+    let first_service = service.clone();
+    let first = tokio::spawn(async move { first_service.compile(first_request).await });
+    let second_service = service.clone();
+    let second = tokio::spawn(async move { second_service.compile(second_request).await });
+    gate.wait_for_starts(2).await;
+    let external = service
+        .acquire_external_work_permit()
+        .await
+        .expect("external work admitted");
+    let mut third = Box::pin(service.compile(third_request));
+    assert_pending(
+        &mut third,
+        "two real compiles plus external work must exhaust the combined limit",
+    )
+    .await;
+    assert!(
+        gate.started() == 2
+            && !first_output.exists()
+            && !second_output.exists()
+            && !third_output.exists(),
+        "the third real compile must remain outside the combined capacity"
+    );
+
+    gate.release();
+    for compile in [first, second] {
+        let response = complete_within_gate_timeout(compile, "held real compile")
+            .await
+            .expect("compile task joined")
+            .expect("held real compile succeeds");
+        assert_eq!(response.exit_code, 0);
+    }
+    let response = complete_within_gate_timeout(third, "third real compile")
+        .await
+        .expect("third real compile succeeds after combined capacity releases");
+    assert_eq!(response.exit_code, 0);
+    assert!(
+        first_output.exists() && second_output.exists() && third_output.exists(),
+        "all real compiles create their requested outputs"
+    );
+    drop(external);
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("shutdown");
+}
+
+#[tokio::test]
+async fn dropped_waiter_and_guard_release_external_work_capacity() {
+    let temp = TempDir::new().expect("temp cache root");
+    let service = ZccacheService::start(config(&temp, "drop-release", Some(1)))
         .await
         .expect("service start");
-    let first = service
-        .acquire_compile_permit()
+    let held = service
+        .acquire_external_work_permit()
         .await
-        .expect("first admission")
-        .expect("configured limit returns a permit");
-    let queued_service = service.clone();
-    let queued = tokio::spawn(async move { queued_service.acquire_compile_permit().await });
+        .expect("first external work admitted");
+    let waiting_service = service.clone();
+    let (waiting_tx, waiting_rx) = oneshot::channel();
+    let waiter = tokio::spawn(async move {
+        waiting_tx.send(()).expect("test observes waiter");
+        waiting_service.acquire_external_work_permit().await
+    });
+    waiting_rx.await.expect("waiter started");
     tokio::task::yield_now().await;
+    waiter.abort();
+    assert!(waiter.await.is_err(), "aborted waiter must finish");
 
-    let shutdown = tokio::spawn(service.shutdown(ShutdownMode::Force));
-    let outcome = tokio::time::timeout(std::time::Duration::from_secs(1), queued)
+    drop(held);
+    let released = service
+        .acquire_external_work_permit()
         .await
-        .expect("forced shutdown must wake queued admission")
-        .expect("queued task joined");
+        .expect("dropped waiter must not consume capacity");
+    drop(released);
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("shutdown");
+}
+
+#[tokio::test]
+async fn host_cancellation_wakes_external_work_waiters() {
+    let temp = TempDir::new().expect("temp cache root");
+    let cancellation = CancellationToken::new();
+    let mut service_config = config(&temp, "external-cancellation", Some(1));
+    service_config.cancellation = Some(cancellation.clone());
+    let service = ZccacheService::start(service_config)
+        .await
+        .expect("service start");
+    let held = service
+        .acquire_external_work_permit()
+        .await
+        .expect("first external work admitted");
+    let queued_service = service.clone();
+    let (waiting_tx, waiting_rx) = oneshot::channel();
+    let (outcome_tx, outcome_rx) = oneshot::channel();
+    let queued = tokio::spawn(async move {
+        waiting_tx
+            .send(())
+            .expect("test observes cancellation waiter");
+        let _ = outcome_tx.send(queued_service.acquire_external_work_permit().await);
+    });
+    waiting_rx.await.expect("cancellation waiter started");
+    tokio::task::yield_now().await;
+    cancellation.cancel();
+    let outcome = outcome_rx.await.expect("cancelled waiter reports outcome");
     assert!(matches!(outcome, Err(EmbeddedError::Cancelled)));
-    drop(first);
+    queued.await.expect("cancelled waiter task joined");
+    drop(held);
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("shutdown after host cancellation");
+}
+
+#[tokio::test]
+async fn graceful_shutdown_wakes_external_work_waiters() {
+    let temp = TempDir::new().expect("temp cache root");
+    let service = ZccacheService::start(config(&temp, "external-shutdown", Some(1)))
+        .await
+        .expect("service start");
+    let held = service
+        .acquire_external_work_permit()
+        .await
+        .expect("first external work admitted");
+    let queued_service = service.clone();
+    let (waiting_tx, waiting_rx) = oneshot::channel();
+    let (outcome_tx, outcome_rx) = oneshot::channel();
+    let queued = tokio::spawn(async move {
+        waiting_tx.send(()).expect("test observes shutdown waiter");
+        let _ = outcome_tx.send(queued_service.acquire_external_work_permit().await);
+    });
+    waiting_rx.await.expect("shutdown waiter started");
+    tokio::task::yield_now().await;
+    let shutdown_service = service.clone();
+    let shutdown =
+        tokio::spawn(async move { shutdown_service.shutdown(ShutdownMode::Graceful).await });
+    let outcome = outcome_rx.await.expect("shutdown waiter reports outcome");
+    assert!(matches!(outcome, Err(EmbeddedError::ShutDown)));
+    queued.await.expect("shutdown waiter task joined");
+    drop(held);
     shutdown
         .await
         .expect("shutdown task joined")
-        .expect("forced shutdown");
+        .expect("graceful shutdown");
+}
+
+#[tokio::test]
+async fn unlimited_external_work_returns_usable_guards() {
+    let temp = TempDir::new().expect("temp cache root");
+    let service = ZccacheService::start(config(&temp, "unlimited-external", None))
+        .await
+        .expect("service start");
+    let first = service
+        .acquire_external_work_permit()
+        .await
+        .expect("first unlimited guard");
+    let second = service
+        .acquire_external_work_permit()
+        .await
+        .expect("second unlimited guard");
+    drop((first, second));
+    service
+        .shutdown(ShutdownMode::Graceful)
+        .await
+        .expect("shutdown");
 }
 
 #[tokio::test]

--- a/crates/zccache-daemon-core/src/embedded/control.rs
+++ b/crates/zccache-daemon-core/src/embedded/control.rs
@@ -3,12 +3,12 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    EmbeddedError, HostAdmissionClassifier, HostIdentity, MaintenanceOwnership, MaintenancePolicy,
-    Result, ZccacheConfig, ZccacheService, ZccacheStartOptions,
+    EmbeddedError, ExternalWorkPermit, HostAdmissionClassifier, HostIdentity, MaintenanceOwnership,
+    MaintenancePolicy, Result, ZccacheConfig, ZccacheService, ZccacheStartOptions,
 };
 use crate::daemon::server::EmbeddedDaemon;
 
@@ -114,6 +114,7 @@ impl ZccacheService {
             shutdown: Arc::new(AtomicBool::new(false)),
             host_cancellation: config.cancellation,
             force_cancellation: CancellationToken::new(),
+            admission_shutdown: CancellationToken::new(),
             compile_permits,
             _host_inflight_guard: host_inflight_guard,
             audit_sink,
@@ -122,7 +123,14 @@ impl ZccacheService {
         })
     }
 
-    pub(super) async fn acquire_compile_permit(&self) -> Result<Option<OwnedSemaphorePermit>> {
+    /// Reserve one unit from the shared embedded compiler-work budget for
+    /// host-owned work. The returned opaque guard releases its reservation on
+    /// drop, including when a host task is cancelled.
+    pub async fn acquire_external_work_permit(&self) -> Result<ExternalWorkPermit> {
+        self.acquire_compile_permit().await
+    }
+
+    pub(super) async fn acquire_compile_permit(&self) -> Result<ExternalWorkPermit> {
         if self.shutdown.load(Ordering::Acquire) {
             return Err(EmbeddedError::ShutDown);
         }
@@ -135,7 +143,7 @@ impl ZccacheService {
             return Err(EmbeddedError::Cancelled);
         }
         let Some(semaphore) = &self.compile_permits else {
-            return Ok(None);
+            return Ok(ExternalWorkPermit { _permit: None });
         };
         let permit = Arc::clone(semaphore).acquire_owned();
         let permit = match &self.host_cancellation {
@@ -144,6 +152,7 @@ impl ZccacheService {
                     biased;
                     () = self.force_cancellation.cancelled() => return Err(EmbeddedError::Cancelled),
                     () = token.cancelled() => return Err(EmbeddedError::Cancelled),
+                    () = self.admission_shutdown.cancelled() => return Err(EmbeddedError::ShutDown),
                     permit = permit => permit,
                 }
             }
@@ -151,12 +160,26 @@ impl ZccacheService {
                 tokio::select! {
                     biased;
                     () = self.force_cancellation.cancelled() => return Err(EmbeddedError::Cancelled),
+                    () = self.admission_shutdown.cancelled() => return Err(EmbeddedError::ShutDown),
                     permit = permit => permit,
                 }
             }
         }
         .map_err(|_| EmbeddedError::ShutDown)?;
-        Ok(Some(permit))
+        if self.force_cancellation.is_cancelled()
+            || self
+                .host_cancellation
+                .as_ref()
+                .is_some_and(CancellationToken::is_cancelled)
+        {
+            return Err(EmbeddedError::Cancelled);
+        }
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(EmbeddedError::ShutDown);
+        }
+        Ok(ExternalWorkPermit {
+            _permit: Some(permit),
+        })
     }
 
     pub(super) async fn await_compile<T, F>(&self, compile: F) -> Result<T>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -39,6 +39,7 @@ failed cache-root audit retain its diagnostic JSONL evidence.
 - **Reflink / hardlink COW safety** → [artifact-store.md](architecture/artifact-store.md#capability-driven-cow-materialization)
 - **soldr target artifact contract** → [rust-artifact-plan.md](architecture/rust-artifact-plan.md)
 - **Embedded soldr/fbuild service integration** → [embedded-service.md](architecture/embedded-service.md)
+- **Shared embedded host-work admission** → [embedded-service.md § Shared host-work admission](architecture/embedded-service.md#shared-host-work-admission)
 - **Embedded heap snapshots** → [embedded-service.md § Heap snapshots](architecture/embedded-service.md#heap-snapshots)
 - **Embedded maintenance limits and shutdown reporting** → [embedded-service.md § Maintenance limits and task ownership](architecture/embedded-service.md#maintenance-limits-and-task-ownership)
 - **Embedded host compiler-admission policy and cache-hit bypass** → [embedded-service.md § Host compiler-admission policy](architecture/embedded-service.md#host-compiler-admission-policy)

--- a/docs/architecture/embedded-service.md
+++ b/docs/architecture/embedded-service.md
@@ -142,6 +142,21 @@ Any persistent write in embedded mode must be rooted under the host-provided
 cache root or audit output root unless the design explicitly documents an
 exception.
 
+### Shared host-work admission
+
+Hosts that start compiler-adjacent work themselves can call
+`ZccacheService::acquire_external_work_permit().await` and retain the returned
+opaque `ExternalWorkPermit` until that work exits. Each guard reserves one slot
+from the exact `ServiceLimits::max_parallel_compiles` semaphore used by
+embedded compiles, so host work and zccache compiles share one combined budget.
+Dropping the guard releases its slot, including when the host task is cancelled.
+
+The permit is admission only: it does not execute a host command, choose a
+tool-specific policy, or add IPC. `None` remains unlimited and returns a
+usable guard without a semaphore reservation. Waiters return cancellation or
+shutdown errors when the host token fires or the service shuts down, rather
+than being left behind a retiring service.
+
 ### Host compiler-admission policy
 
 An embedded host may call
@@ -438,6 +453,8 @@ without a real compiler invocation:
   cloned handles before stopping the engine, and does not wait for audit drain.
 - `ServiceLimits::max_parallel_compiles` bounds admission with an async
   semaphore; `None` is unlimited and zero is rejected at startup.
+- `acquire_external_work_permit()` lets host-owned compiler-adjacent work share
+  that same admission budget through an opaque drop-released guard.
 - Hosts can supply an `EmbeddedEventSink` callback without enabling file audit
   output; callbacks receive redacted structured events and cannot panic the
   compile path.


### PR DESCRIPTION
Closes #1524

Adds an opaque RAII ExternalWorkPermit acquired from the exact semaphore used by embedded compiles. Unlimited services return a zero-cost guard; zero remains rejected. Graceful/forced shutdown, host cancellation, waiter cancellation, and guard drop cannot leak capacity. No Tokio permit type enters the public facade.

RED -> GREEN evidence:
- RED baseline: ZccacheService has no acquire_external_work_permit API, so a host cannot reserve the compile semaphore and the new public contract cannot compile.
- GREEN: real public ZccacheService::compile calls are held at COMPILE_STARTED after admission. Tests prove external-first, compile-first, and combined capacity ordering, then require successful Clang output after release.

Validation:
- soldr cargo test -p zccache-daemon-core --features test-support --lib embedded::contract_tests
- 11 passed
- soldr cargo fmt --all -- --check
- git diff --check
- Independent pre-push review: clean after correcting real-compile coverage and unwind-safe timeout handling