### PR TITLE
fix(cli): diagnose silent wrapper failures

### DIFF
--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc.rs
@@ -6,7 +6,7 @@ use std::path::Path;
 use std::process::ExitCode;
 
 use super::super::super::{link_retry_budget, wedge_recv_timeout};
-use super::super::util::{connect, exit_code_from_i32, slurp_stdin_if_piped, LOST_CONNECTION_MSG};
+use super::super::util::{connect, exit_code_from_i32, slurp_stdin_if_piped};
 use crate::cli::runtime::{current_daemon_instance, ensure_daemon, stop_wedged_daemon};
 
 pub(super) async fn cmd_compile(
@@ -197,14 +197,67 @@ enum RelayOutcome {
     /// The daemon completed the request without returning a compiler/tool
     /// verdict. This is intentionally not eligible for local fallback: the
     /// daemon may have already executed the tool or changed output state.
-    NoVerdict(String),
+    NoVerdict(RelayFailureDiagnostic),
+}
+
+/// Stable categories for a terminal daemon response that lacks a compiler
+/// verdict. These are wrapper failures, not compiler statuses: a compiler
+/// `255` remains a [`RelayOutcome::Verdict`] and is relayed unchanged.
+#[derive(Debug, PartialEq, Eq)]
+enum RelayFailureCause {
+    DaemonError,
+    ClosedConnection,
+    UnexpectedResponse,
+}
+
+impl RelayFailureCause {
+    const fn as_str(&self) -> &'static str {
+        match self {
+            Self::DaemonError => "daemon-error",
+            Self::ClosedConnection => "closed-connection",
+            Self::UnexpectedResponse => "unexpected-response",
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq)]
+struct RelayFailureDiagnostic {
+    cause: RelayFailureCause,
+    context: String,
+}
+
+impl RelayFailureDiagnostic {
+    fn write_to<W: Write>(&self, stderr: &mut W) -> std::io::Result<()> {
+        write!(
+            stderr,
+            "zccache[err][R]: daemon response failure ({}): ",
+            self.cause.as_str()
+        )?;
+        for character in self.context.chars() {
+            match character {
+                '\n' | '\r' => stderr.write_all(b" ")?,
+                _ => write!(stderr, "{character}")?,
+            }
+        }
+        writeln!(
+            stderr,
+            ". The requested tool returned no status; run 'zccache status' then retry."
+        )
+    }
 }
 
 fn report_relay_outcome(outcome: RelayOutcome) -> ExitCode {
+    report_relay_outcome_to_writer(outcome, &mut std::io::stderr())
+}
+
+fn report_relay_outcome_to_writer<W: Write>(outcome: RelayOutcome, stderr: &mut W) -> ExitCode {
     match outcome {
         RelayOutcome::Verdict(code) => code,
-        RelayOutcome::NoVerdict(message) => {
-            eprintln!("{message}");
+        RelayOutcome::NoVerdict(diagnostic) => {
+            // Preserve the wrapper's existing best-effort stderr policy: a
+            // failed diagnostic write cannot turn a known compiler status
+            // into a wrapper status, nor can it justify a retry/fallback.
+            let _ = diagnostic.write_to(stderr);
             ExitCode::FAILURE
         }
     }
@@ -839,15 +892,33 @@ fn relay_compile_response_with_color<W: Write, E: Write>(
         }) => {
             let _ = stdout.write_all(&out);
             let _ = write_relay_stderr(stderr, &err, color_unknown_warning);
+            if exit_code == 255 && err.is_empty() {
+                // A terminal result remains the tool's status. This advisory
+                // only makes the otherwise-silent shape actionable; it does
+                // not infer whether the tool, daemon, or transport produced
+                // it.
+                let _ = writeln!(
+                    stderr,
+                    "zccache[warn][R]: compile result reported exit 255 without stderr; \
+                     source is unknown. Run 'zccache status' then retry."
+                );
+            }
             RelayOutcome::Verdict(exit_code_from_i32(exit_code))
         }
         Some(crate::protocol::Response::Error { message }) => {
-            RelayOutcome::NoVerdict(format!("zccache[err][E]: daemon error: {message}"))
+            RelayOutcome::NoVerdict(RelayFailureDiagnostic {
+                cause: RelayFailureCause::DaemonError,
+                context: message,
+            })
         }
-        None => RelayOutcome::NoVerdict(LOST_CONNECTION_MSG.to_string()),
-        Some(other) => RelayOutcome::NoVerdict(format!(
-            "zccache[err][U]: unexpected response from daemon: {other:?}"
-        )),
+        None => RelayOutcome::NoVerdict(RelayFailureDiagnostic {
+            cause: RelayFailureCause::ClosedConnection,
+            context: "lost connection to daemon (no response)".to_string(),
+        }),
+        Some(other) => RelayOutcome::NoVerdict(RelayFailureDiagnostic {
+            cause: RelayFailureCause::UnexpectedResponse,
+            context: format!("unexpected response from daemon: {other:?}"),
+        }),
     }
 }
 
@@ -889,12 +960,19 @@ fn relay_link_response_with_color<W: Write, E: Write>(
             RelayOutcome::Verdict(exit_code_from_i32(exit_code))
         }
         Some(crate::protocol::Response::Error { message }) => {
-            RelayOutcome::NoVerdict(format!("zccache[err][E]: daemon error: {message}"))
+            RelayOutcome::NoVerdict(RelayFailureDiagnostic {
+                cause: RelayFailureCause::DaemonError,
+                context: message,
+            })
         }
-        None => RelayOutcome::NoVerdict(LOST_CONNECTION_MSG.to_string()),
-        Some(other) => RelayOutcome::NoVerdict(format!(
-            "zccache[err][U]: unexpected response from daemon: {other:?}"
-        )),
+        None => RelayOutcome::NoVerdict(RelayFailureDiagnostic {
+            cause: RelayFailureCause::ClosedConnection,
+            context: "lost connection to daemon (no response)".to_string(),
+        }),
+        Some(other) => RelayOutcome::NoVerdict(RelayFailureDiagnostic {
+            cause: RelayFailureCause::UnexpectedResponse,
+            context: format!("unexpected response from daemon: {other:?}"),
+        }),
     }
 }
 

--- a/crates/zccache-cli-core/src/cli/commands/wrap/ipc/tests.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/ipc/tests.rs
@@ -82,6 +82,75 @@ fn compile_response_relay_writes_stdout_stderr_and_exit_code() {
 }
 
 #[test]
+fn compiler_exit_255_with_stderr_preserves_compiler_stderr_without_wrapper_relabeling() {
+    let mut stdout = Vec::new();
+    let mut compiler_stderr = Vec::new();
+    let outcome = relay_compile_response(
+        Some(crate::protocol::Response::CompileResult {
+            exit_code: 255,
+            stdout: Arc::new(Vec::new()),
+            stderr: Arc::new(b"LLVM ERROR: compiler diagnostic\n".to_vec()),
+            cached: false,
+        }),
+        &mut stdout,
+        &mut compiler_stderr,
+    );
+    let mut wrapper_stderr = Vec::new();
+
+    assert_eq!(
+        report_relay_outcome_to_writer(outcome, &mut wrapper_stderr),
+        ExitCode::from(255)
+    );
+    assert_eq!(compiler_stderr, b"LLVM ERROR: compiler diagnostic\n");
+    assert!(
+        wrapper_stderr.is_empty(),
+        "a compiler verdict is never relabeled"
+    );
+}
+
+#[test]
+fn compiler_exit_255_without_stderr_gets_one_cautious_wrapper_diagnostic() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let outcome = relay_compile_response(
+        Some(crate::protocol::Response::CompileResult {
+            exit_code: 255,
+            stdout: Arc::new(Vec::new()),
+            stderr: Arc::new(Vec::new()),
+            cached: false,
+        }),
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(outcome, RelayOutcome::Verdict(ExitCode::from(255)));
+    assert_eq!(
+        String::from_utf8(stderr).unwrap(),
+        "zccache[warn][R]: compile result reported exit 255 without stderr; \
+         source is unknown. Run 'zccache status' then retry.\n"
+    );
+}
+
+#[test]
+fn empty_stderr_for_a_non_255_compiler_exit_is_not_diagnosed() {
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let outcome = relay_compile_response(
+        Some(crate::protocol::Response::CompileResult {
+            exit_code: 1,
+            stdout: Arc::new(Vec::new()),
+            stderr: Arc::new(Vec::new()),
+            cached: false,
+        }),
+        &mut stdout,
+        &mut stderr,
+    );
+
+    assert_eq!(outcome, RelayOutcome::Verdict(ExitCode::from(1)));
+    assert!(stderr.is_empty());
+}
+
+#[test]
 fn compile_response_relay_colors_only_unknown_warning_on_terminal() {
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
@@ -118,11 +187,84 @@ fn daemon_error_is_a_no_verdict_failure_not_a_local_fallback_signal() {
         &mut stderr,
     );
 
-    assert!(
-        matches!(outcome, RelayOutcome::NoVerdict(message) if message.contains("cache staging failed"))
-    );
+    assert!(matches!(
+        outcome,
+        RelayOutcome::NoVerdict(RelayFailureDiagnostic {
+            cause: RelayFailureCause::DaemonError,
+            context,
+        }) if context == "cache staging failed"
+    ));
     assert!(stdout.is_empty());
     assert!(stderr.is_empty());
+}
+
+#[test]
+fn daemon_response_failures_emit_one_actionable_diagnostic_with_cause_and_context() {
+    let cases = [
+        (
+            relay_compile_response(
+                Some(crate::protocol::Response::Error {
+                    message: "cache staging\nfailed".to_string(),
+                }),
+                &mut Vec::new(),
+                &mut Vec::new(),
+            ),
+            "daemon-error",
+            "cache staging failed",
+        ),
+        (
+            relay_compile_response(None, &mut Vec::new(), &mut Vec::new()),
+            "closed-connection",
+            "lost connection to daemon (no response)",
+        ),
+        (
+            relay_compile_response(
+                Some(crate::protocol::Response::Pong),
+                &mut Vec::new(),
+                &mut Vec::new(),
+            ),
+            "unexpected-response",
+            "Pong",
+        ),
+    ];
+
+    for (outcome, cause, context) in cases {
+        let mut stderr = Vec::new();
+        assert_eq!(
+            report_relay_outcome_to_writer(outcome, &mut stderr),
+            ExitCode::FAILURE,
+            "the nearest existing internal/transport failure mapping remains failure"
+        );
+        let diagnostic = String::from_utf8(stderr).unwrap();
+        assert_eq!(diagnostic.matches("zccache[err]").count(), 1);
+        assert_eq!(diagnostic.lines().count(), 1);
+        assert!(diagnostic.contains(&format!("({cause})")));
+        assert!(diagnostic.contains(context));
+        assert!(diagnostic.contains("requested tool returned no status"));
+        assert!(diagnostic.contains("zccache status"));
+    }
+}
+
+#[test]
+fn link_daemon_error_uses_the_same_response_failure_diagnostic() {
+    let outcome = relay_link_response(
+        Some(crate::protocol::Response::Error {
+            message: "archive staging failed".to_string(),
+        }),
+        &mut Vec::new(),
+        &mut Vec::new(),
+    );
+    let mut stderr = Vec::new();
+
+    assert_eq!(
+        report_relay_outcome_to_writer(outcome, &mut stderr),
+        ExitCode::FAILURE
+    );
+    assert_eq!(
+        String::from_utf8(stderr).unwrap(),
+        "zccache[err][R]: daemon response failure (daemon-error): archive staging failed. \
+         The requested tool returned no status; run 'zccache status' then retry.\n"
+    );
 }
 
 #[test]
@@ -131,7 +273,13 @@ fn missing_response_is_a_no_verdict_failure() {
     let mut stderr = Vec::new();
     let outcome = relay_compile_response(None, &mut stdout, &mut stderr);
 
-    assert!(matches!(outcome, RelayOutcome::NoVerdict(_)));
+    assert!(matches!(
+        outcome,
+        RelayOutcome::NoVerdict(RelayFailureDiagnostic {
+            cause: RelayFailureCause::ClosedConnection,
+            ..
+        })
+    ));
 }
 
 // ── Issue #666: wedge-detection helper ──────────────────────────────
@@ -363,6 +511,47 @@ async fn compile_progress_is_never_relayed_as_a_terminal_response() {
     let mut stderr = Vec::new();
     let relayed = relay_compile_response(response, &mut stdout, &mut stderr);
     assert_eq!(relayed, RelayOutcome::Verdict(exit_code_from_i32(7)));
+}
+
+#[tokio::test]
+async fn queue_progress_is_not_reported_as_the_cause_of_a_terminal_daemon_error() {
+    let mut conn = FakeConn {
+        behavior: FakeBehavior::Scripted(
+            [
+                (std::time::Duration::ZERO, progress(2, 5)),
+                (
+                    std::time::Duration::ZERO,
+                    crate::protocol::Response::Error {
+                        message: "internal staging failure".to_string(),
+                    },
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+    };
+    let outcome = compile_recv_with_wedge_detection(
+        &mut conn,
+        TEST_BUDGET,
+        crate::protocol::wire_prost::WireFormat::BincodeV15,
+    )
+    .await;
+    let CompileRecvOutcome::Done(response) = outcome else {
+        panic!("expected the terminal daemon error after queue progress");
+    };
+    let mut stdout = Vec::new();
+    let mut compiler_stderr = Vec::new();
+    let relayed = relay_compile_response(response, &mut stdout, &mut compiler_stderr);
+    let mut wrapper_stderr = Vec::new();
+
+    assert_eq!(
+        report_relay_outcome_to_writer(relayed, &mut wrapper_stderr),
+        ExitCode::FAILURE
+    );
+    let diagnostic = String::from_utf8(wrapper_stderr).unwrap();
+    assert!(diagnostic.contains("(daemon-error)"));
+    assert!(diagnostic.contains("internal staging failure"));
+    assert!(!diagnostic.contains("queue"));
 }
 
 #[test]


### PR DESCRIPTION
Closes #1543

Eliminates silent terminal wrapper failures without inventing a root cause. Daemon Error, EOF, and unexpected responses now produce one stable actionable diagnostic. The exact reported shape—CompileResult exit 255 with empty stderr—gets one neutral source-unknown advisory while preserving exit 255. A real compiler diagnostic is relayed byte-for-byte without wrapper relabeling, and non-255 empty stderr remains unchanged. Queue progress stays nonterminal and is never blamed.

Validation:
- soldr cargo test -p zccache-cli-core --features cli --lib cli::commands::wrap::ipc::tests
- 30 passed
- soldr cargo fmt --all -- --check
- git diff --check
- Independent pre-push review: clean after exact silent-255 and tool-neutral wording corrections