### PR TITLE
ci: run native Python suites

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -3,7 +3,7 @@
 GitHub Actions workflow definitions.
 
 - **ci.yml** - Runs fmt, Dylint, MSRV, and doc builds on main and pull requests.
-- **python-tests.yml** - Runs the `ci/tests/` pytest suite (CI helper modules plus the doc-link, README-coverage, crate-map, documented-command, and toolchain-consistency guards). Separate from `ci.yml` because that workflow ignores `**/*.md`, which would skip the Markdown guards on docs-only PRs.
+- **python-tests.yml** - Runs the fast `ci/tests/` pytest suite (CI helper modules plus the doc-link, README-coverage, crate-map, documented-command, and toolchain-consistency guards), plus a Linux-native job that builds/stages all three PyO3 extensions and runs every source Python suite against an isolated pre-started zccache daemon. Separate from `ci.yml` because that workflow ignores `**/*.md`, which would skip the Markdown guards on docs-only PRs.
 - **ci-check.yml** - Reusable check/test workflow used by the OS-specific CI workflows.
 - **integration.yml** - Runs the normal Linux workspace integration suite on pushes and PRs; weekly/manual runs additionally execute every ignored integration/stress test without gating pull requests.
 - **fs-matrix.yml** - Requires real ReFS/FAT, btrfs/ext4/vfat, and macOS fixtures on PRs; scheduled/manual runs also execute >4 GiB ReFS and btrfs COW acceptance.

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,8 +1,12 @@
 name: Python Tests
 
-# Runs the pytest suite under `ci/tests/` -- ~430 tests covering the CI helper
-# modules in `ci/` plus the repo-hygiene guards (doc links, README coverage,
-# crate map, documented commands, toolchain consistency).
+# Runs two Python test shapes:
+#   * the fast `ci/tests/` repo-hygiene suite, which needs no native build;
+#   * all source Python suites with the three real PyO3 modules staged in place.
+#
+# The native job is Linux-only by design.  Release wheel smoke tests cover the
+# other native platform families; a matrix here would rebuild the same PyO3
+# contracts without adding a distinct source-level test surface.
 #
 # This is a dedicated workflow rather than a job in `ci.yml` because `ci.yml`
 # sets `paths-ignore: "**/*.md"`. Several of these tests exist specifically to
@@ -78,3 +82,109 @@ jobs:
             --with pillow \
             --with pyyaml \
             python -m pytest ci/tests -q -rs --durations=10
+
+  native-pytest:
+    name: native Python suites (Linux)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      # The PyO3 modules use abi3-py310, and 3.13 is the canonical workflow
+      # interpreter. setup-python also supplies the interpreter PYO3 probes.
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: ".github/workflows/python-tests.yml"
+
+      - uses: zackees/setup-soldr@5f1f68dcb8377818413c28ce52214261ae8ff771
+        with:
+          zccache-seed-strict: true
+          toolchain: 1.95.0
+          cache: true
+          linker: fast
+          prebuild-deps: soldr-cook
+          solo-toolchain-cache: true
+
+      - name: Build native Python test artifacts
+        shell: bash
+        run: |
+          export PYO3_PYTHON="$(uv python find 3.13)"
+          # Keep each package in a separate Cargo invocation. Combining the
+          # three cdylibs makes Windows link the same PyO3 symbols twice.
+          soldr cargo build --release -p zccache --features zccache-bin --bin zccache
+          soldr cargo build --release -p zccache-cli --features python --lib
+          # #1497 split these featureless PyO3 hosts from their rlib engines;
+          # `python` is intentionally only a feature of zccache-cli.
+          soldr cargo build --release -p zccache-watcher-py --lib
+          soldr cargo build --release -p zccache-fingerprint-py --lib
+
+      - name: Stage native Python extensions
+        shell: bash
+        run: |
+          EXT_SUFFIX="$(uv run --no-project --python 3.13 python -c 'import sysconfig; print(sysconfig.get_config_var("EXT_SUFFIX"))')"
+          test -n "$EXT_SUFFIX"
+          cp target/release/libzccache_cli.so "python/zccache/_native$EXT_SUFFIX"
+          cp target/release/libzccache_watcher.so "python/zccache/watcher/_native$EXT_SUFFIX"
+          cp target/release/libzccache_fingerprint.so "python/zccache/fingerprint/_native$EXT_SUFFIX"
+          cp target/release/libzccache_watcher.so "crates/zccache-watcher/python/zccache/watcher/_native$EXT_SUFFIX"
+          cp target/release/libzccache_fingerprint.so "crates/zccache-fingerprint/python/zccache/fingerprint/_native$EXT_SUFFIX"
+          # NativeClient must see a daemon started from the real multi-call
+          # binary, not attempt to deploy the Python interpreter as a daemon.
+          echo "$GITHUB_WORKSPACE/target/release" >> "$GITHUB_PATH"
+
+      - name: Start isolated native Python daemon
+        shell: bash
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-python-tests/cache
+          ZCCACHE_DAEMON_NAMESPACE: native-python-tests
+        run: |
+          target/release/zccache start
+          for attempt in $(seq 1 30); do
+            if target/release/zccache status; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "zccache daemon did not become ready" >&2
+          exit 1
+
+      - name: Run native Python suites
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-python-tests/cache
+          ZCCACHE_DAEMON_NAMESPACE: native-python-tests
+        run: |
+          PYTHONPATH=python uv run --no-project --python 3.13 \
+            --with pytest \
+            --with clang-tool-chain-bins \
+            python -m pytest \
+            python/tests \
+            -q -rs --durations=10
+          # The watcher and fingerprint roots both expose a top-level `tests`
+          # package. Keep their collection processes separate so neither can
+          # shadow the other's module names or use an installed distribution.
+          PYTHONPATH=crates/zccache-watcher/python uv run --no-project --python 3.13 \
+            --with pytest \
+            python -m pytest \
+            crates/zccache-watcher/python/tests \
+            -q -rs --durations=10
+          PYTHONPATH=crates/zccache-fingerprint/python uv run --no-project --python 3.13 \
+            --with pytest \
+            python -m pytest \
+            crates/zccache-fingerprint/python/tests \
+            -q -rs --durations=10
+
+      - name: Stop isolated native Python daemon
+        if: always()
+        shell: bash
+        env:
+          ZCCACHE_CACHE_DIR: ${{ runner.temp }}/zccache-python-tests/cache
+          ZCCACHE_DAEMON_NAMESPACE: native-python-tests
+        run: |
+          target/release/zccache stop || true
+          rm -rf "$ZCCACHE_CACHE_DIR"

--- a/ci/tests/test_native_python_workflow.py
+++ b/ci/tests/test_native_python_workflow.py
@@ -1,0 +1,149 @@
+"""Static contract for the native Python source-suite workflow (#1494)."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "python-tests.yml"
+
+# `conftest.py` is included because it is a tracked module loaded by the
+# python/tests group. The three package __init__.py files are collection markers,
+# not runnable test modules.
+NATIVE_TEST_MODULES = (
+    "python/tests/test_public_api.py",
+    "python/tests/cpp_lint/conftest.py",
+    "python/tests/cpp_lint/test_cache.py",
+    "python/tests/cpp_lint/test_clang_query_integration.py",
+    "python/tests/cpp_lint/test_listorpath.py",
+    "python/tests/cpp_lint/test_runner_no_tools.py",
+    "python/tests/cpp_lint/test_toml.py",
+    "python/tests/cpp_lint/test_tools_resolution.py",
+    "python/tests/cpp_lint/test_types.py",
+    "python/tests/cpp_lint/test_validation.py",
+    "crates/zccache-watcher/python/tests/test_compat.py",
+    "crates/zccache-watcher/python/tests/test_keyboard_interrupt_behavior.py",
+    "crates/zccache-fingerprint/python/tests/test_hash.py",
+    "crates/zccache-fingerprint/python/tests/test_manager.py",
+    "crates/zccache-fingerprint/python/tests/test_result.py",
+)
+NATIVE_TEST_GROUPS = (
+    "python/tests",
+    "crates/zccache-watcher/python/tests",
+    "crates/zccache-fingerprint/python/tests",
+)
+
+
+def _job(workflow: str, name: str) -> str:
+    marker = f"  {name}:\n"
+    start = workflow.index(marker)
+    following = re.search(
+        r"^  [a-z][a-z0-9-]*:\n",
+        workflow[start + len(marker) :],
+        re.MULTILINE,
+    )
+    end = start + len(marker) + following.start() if following else len(workflow)
+    return workflow[start:end]
+
+
+def _step(job: str, name: str) -> str:
+    marker = f"      - name: {name}\n"
+    start = job.index(marker)
+    following = job.find("\n      - name:", start + len(marker))
+    return job[start : following if following != -1 else len(job)]
+
+
+def test_native_python_job_builds_every_extension_separately() -> None:
+    native = _job(WORKFLOW.read_text(encoding="utf-8"), "native-pytest")
+    build = _step(native, "Build native Python test artifacts")
+
+    assert "runs-on: ubuntu-latest" in native
+    assert "zackees/setup-soldr@5f1f68dcb8377818413c28ce52214261ae8ff771" in native
+    assert "toolchain: 1.95.0" in native
+    expected_builds = (
+        "soldr cargo build --release -p zccache --features zccache-bin --bin zccache",
+        "soldr cargo build --release -p zccache-cli --features python --lib",
+        "soldr cargo build --release -p zccache-watcher-py --lib",
+        "soldr cargo build --release -p zccache-fingerprint-py --lib",
+    )
+    assert build.count("soldr cargo build") == len(expected_builds)
+    for command in expected_builds:
+        assert command in build
+    assert 'export PYO3_PYTHON="$(uv python find 3.13)"' in build
+    assert "PYO3_PYTHON: python" not in native
+
+
+def test_native_python_job_stages_extensions_and_prestarts_the_real_binary() -> None:
+    native = _job(WORKFLOW.read_text(encoding="utf-8"), "native-pytest")
+    stage = _step(native, "Stage native Python extensions")
+    start = _step(native, "Start isolated native Python daemon")
+
+    assert "EXT_SUFFIX" in stage
+    assert "uv run --no-project --python 3.13 python -c" in stage
+    assert 'EXT_SUFFIX="$(python -c' not in stage
+    for destination in (
+        "python/zccache/_native$EXT_SUFFIX",
+        "python/zccache/watcher/_native$EXT_SUFFIX",
+        "python/zccache/fingerprint/_native$EXT_SUFFIX",
+        "crates/zccache-watcher/python/zccache/watcher/_native$EXT_SUFFIX",
+        "crates/zccache-fingerprint/python/zccache/fingerprint/_native$EXT_SUFFIX",
+    ):
+        assert destination in stage
+    assert 'echo "$GITHUB_WORKSPACE/target/release" >> "$GITHUB_PATH"' in stage
+    assert "target/release/zccache start" in start
+    assert "target/release/zccache status" in start
+    assert "seq 1 30" in start
+    assert "ZCCACHE_CACHE_DIR" in start
+    assert "ZCCACHE_DAEMON_NAMESPACE: native-python-tests" in start
+
+
+def test_native_python_job_runs_every_tracked_module_without_deselection() -> None:
+    native = _job(WORKFLOW.read_text(encoding="utf-8"), "native-pytest")
+    pytest = _step(native, "Run native Python suites")
+
+    assert len(NATIVE_TEST_MODULES) == 15
+    assert all((ROOT / module).is_file() for module in NATIVE_TEST_MODULES)
+    invocations = pytest.split("python -m pytest")
+    assert pytest.count("python -m pytest") == 3
+    assert len(invocations) == 4, "each source suite must get its own pytest process"
+    source_roots = (
+        "PYTHONPATH=python",
+        "PYTHONPATH=crates/zccache-watcher/python",
+        "PYTHONPATH=crates/zccache-fingerprint/python",
+    )
+    for group, source_root, launch, invocation in zip(
+        NATIVE_TEST_GROUPS, source_roots, invocations, invocations[1:]
+    ):
+        assert group in invocation
+        assert f"{source_root} uv run --no-project --python 3.13" in launch
+        assert sum(
+            line.strip().rstrip("\\").strip() == group
+            for line in pytest.splitlines()
+        ) == 1
+    assert "--with clang-tool-chain-bins" in invocations[0]
+    assert "--with clang-tool-chain-bins" not in invocations[1]
+    assert "--with clang-tool-chain-bins" not in invocations[2]
+    assert all(
+        any(module == group or module.startswith(f"{group}/") for group in NATIVE_TEST_GROUPS)
+        for module in NATIVE_TEST_MODULES
+    )
+    assert "uv run --no-project --python 3.13" in pytest
+    assert "--deselect" not in pytest
+    assert "--ignore" not in pytest
+    assert " -k " not in pytest
+    assert "--skip" not in pytest
+    assert "ZCCACHE_CACHE_DIR" in pytest
+    assert "ZCCACHE_DAEMON_NAMESPACE: native-python-tests" in pytest
+    assert "PYTHONPATH: ." not in native
+
+
+def test_native_python_job_always_stops_and_removes_its_isolated_cache() -> None:
+    native = _job(WORKFLOW.read_text(encoding="utf-8"), "native-pytest")
+    cleanup = _step(native, "Stop isolated native Python daemon")
+
+    assert "if: always()" in cleanup
+    assert "target/release/zccache stop || true" in cleanup
+    assert 'rm -rf "$ZCCACHE_CACHE_DIR"' in cleanup
+    assert "ZCCACHE_CACHE_DIR" in cleanup
+    assert "ZCCACHE_DAEMON_NAMESPACE: native-python-tests" in cleanup

--- a/python/tests/test_public_api.py
+++ b/python/tests/test_public_api.py
@@ -72,7 +72,8 @@ def test_fingerprint_cache_lifecycle() -> None:
 
         first = fp.check(root=root, include=["**/*.cpp"])
         assert first.should_run is True
-        assert first.changed_files
+        assert first.reason == "no cache file"
+        assert first.changed_files == ()
 
         fp.mark_success()
 
@@ -82,7 +83,7 @@ def test_fingerprint_cache_lifecycle() -> None:
         source.write_text("int main() { return 1; }\n", encoding="utf-8")
         third = fp.check(root=root, include=["**/*.cpp"])
         assert third.should_run is True
-        assert str(source.resolve()) in third.changed_files
+        assert "main.cpp" in third.changed_files
 
 
 def test_client_session_lifecycle() -> None:


### PR DESCRIPTION
Closes #1494.

Adds a dedicated Linux native-Python CI job that:

- builds the daemon and all three PyO3 extensions in separate Soldr invocations
- stages artifacts into both the combined package and crate-local source trees
- pre-starts an isolated real zccache daemon
- runs all three tracked source-suite roots in separate pytest processes with source-pinned PYTHONPATH values
- always stops the daemon and cleans the isolated cache

The work also repairs two stale fingerprint lifecycle assertions to match the documented daemon contract: an initial no-cache result has no changed-file diff, and later changed paths are root-relative.

Validation:
- native workflow contract: 4 passed
- python/tests: 64 passed, 1 environment-dependent skip
- watcher source tests: 13 passed
- fingerprint source tests: 24 passed
- all four release artifacts built separately with Rust 1.95.0
- import traces verified every native module came from the staged repository source tree
- clud-review: clean