### PR TITLE
refactor: register owned env flag policy (#1478)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,12 +203,20 @@ jobs:
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_discarded_write_result/Cargo.toml
       - name: Check Dylint Library Formatting (enforce_platform_boundary)
         run: soldr cargo fmt --manifest-path dylints/enforce_platform_boundary/Cargo.toml --all -- --check
+      - name: Check Dylint Library Formatting (ban_registered_env_read)
+        run: soldr cargo fmt --manifest-path dylints/ban_registered_env_read/Cargo.toml --all -- --check
       - name: Test Dylint Library (enforce_platform_boundary)
         run: |
           export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
           export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
           export RUSTUP_TOOLCHAIN=nightly-2026-05-26
           soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/enforce_platform_boundary/Cargo.toml
+      - name: Test Dylint Library (ban_registered_env_read)
+        run: |
+          export PATH="${DYLINT_CARGO_SHIM}:${PATH}"
+          export RUSTC="$(soldr rustup which --toolchain nightly-2026-05-26 rustc)"
+          export RUSTUP_TOOLCHAIN=nightly-2026-05-26
+          soldr rustup run nightly-2026-05-26 cargo test --manifest-path dylints/ban_registered_env_read/Cargo.toml
       - name: Run Dylint
         # ZCCACHE_DISABLE: the lint-library builds fail with "Could not find
         # lib<name>@<toolchain>.so despite successful build" whenever the

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ exclude = [
     "dylints/ban_dashmap_guard_across_blocking",
     "dylints/ban_discarded_write_result",
     "dylints/enforce_platform_boundary",
+    "dylints/ban_registered_env_read",
 ]
 
 [workspace.package]

--- a/ci/lint.py
+++ b/ci/lint.py
@@ -295,6 +295,7 @@ def lint_workspace():
             "dylints/ban_dashmap_guard_across_blocking/Cargo.toml",
             "dylints/ban_discarded_write_result/Cargo.toml",
             "dylints/enforce_platform_boundary/Cargo.toml",
+            "dylints/ban_registered_env_read/Cargo.toml",
         ):
             result = run_cmd(cargo_command(
                 "fmt",

--- a/crates/zccache-cli-core/src/cli/commands/wrap/env.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/env.rs
@@ -149,7 +149,7 @@ pub(super) fn client_env(overrides: WrapperOverrides) -> Vec<(String, String)> {
 }
 
 pub(super) fn wrapper_disabled() -> bool {
-    crate::core::config::owned_env_flag_enabled("ZCCACHE_DISABLE")
+    crate::core::config::zccache_disabled()
 }
 
 fn set_client_env(env: &mut Vec<(String, String)>, key: &str, value: String) {

--- a/crates/zccache-cli-core/src/cli/commands/wrap/routing.rs
+++ b/crates/zccache-cli-core/src/cli/commands/wrap/routing.rs
@@ -46,7 +46,7 @@ pub(super) fn classify_invocation(tool: &str, tool_args: &[String]) -> WrapperRo
 /// without restarting the daemon. Default: disabled — opt-in only until
 /// the heuristic has shipped to enough downstream consumers.
 fn probe_bypass_enabled() -> bool {
-    crate::core::config::owned_env_flag_enabled("ZCCACHE_PROBE_BYPASS")
+    crate::core::config::probe_bypass_enabled()
 }
 
 /// Returns `true` when `tool_args` describes a probe-shaped compile that

--- a/crates/zccache-compiler/src/parse_rustc.rs
+++ b/crates/zccache-compiler/src/parse_rustc.rs
@@ -53,27 +53,24 @@ const RUSTC_CACHEABLE_CRATE_TYPES: &[&str] = &["lib", "rlib", "staticlib", "proc
 /// crate-type table.
 ///
 /// The exclusion keys on `--test` itself, not on the crate type. See
-/// [`CACHE_TEST_BINS_ENV`] for the opt-in escape hatch.
+/// [`zccache_core::config::CACHE_TEST_BINS_ENV`] for the opt-in escape hatch.
 const RUSTC_TEST_HARNESS_REASON: &str = "test harness link product not cacheable";
 
-/// Opt-in re-admission of `--test` harness invocations (zccache#1525).
+/// True when [`zccache_core::config::CACHE_TEST_BINS_ENV`] opts this process
+/// back into caching `--test` harness links (zccache#1525).
 ///
 /// Set it if you can demonstrate a real hit rate on your workload — e.g. a
 /// build where the harness's input closure genuinely does not move between
 /// runs. Off by default because the common case is the opposite.
 ///
 /// Value grammar is the canonical zccache-owned boolean, parsed by
-/// [`zccache_core::config::owned_env_flag_enabled`]: `1` or case-insensitive
+/// [`zccache_core::config::cache_test_binaries_enabled`]: `1` or case-insensitive
 /// `true` enables it, and everything else — unset, empty, `0`, `false`, or any
 /// typo — leaves the exclusion in force. Deliberately NOT a hand-rolled
 /// parser: soldr#2740 found five mutually disagreeing truthy parsers in the
 /// sibling repo, one of which made `FOO=false` turn a switch *on*.
-pub(crate) const CACHE_TEST_BINS_ENV: &str = "ZCCACHE_CACHE_TEST_BINS";
-
-/// True when [`CACHE_TEST_BINS_ENV`] opts this process back into caching
-/// `--test` harness links.
 fn test_harness_caching_enabled() -> bool {
-    zccache_core::config::owned_env_flag_enabled(CACHE_TEST_BINS_ENV)
+    zccache_core::config::cache_test_binaries_enabled()
 }
 
 /// Host dynamic-library file-name pattern for proc-macros, matching
@@ -268,7 +265,8 @@ pub(crate) fn parse_rustc_invocation(compiler: &str, args: &[String]) -> ParsedI
 
 /// Testable core of [`parse_rustc_invocation`] — no environment access.
 ///
-/// `cache_test_bins` is the already-resolved value of [`CACHE_TEST_BINS_ENV`].
+/// `cache_test_bins` is the already-resolved value of
+/// [`zccache_core::config::CACHE_TEST_BINS_ENV`].
 /// Threading it in as an argument keeps the crate's parallel test suite
 /// deterministic: no test has to mutate process-global environment state to
 /// exercise either side of the policy. Mirrors the

--- a/crates/zccache-compiler/src/tests/rustc.rs
+++ b/crates/zccache-compiler/src/tests/rustc.rs
@@ -1,9 +1,9 @@
 //! Rustc invocation parsing: crate types, --emit, --out-dir, proc-macro/bin output naming.
 
-use super::super::parse_rustc::{parse_rustc_invocation_with_policy, CACHE_TEST_BINS_ENV};
+use super::super::parse_rustc::parse_rustc_invocation_with_policy;
 use super::super::{detect_family, parse_invocation, CompilerFamily, ParsedInvocation};
 use super::args;
-use zccache_core::NormalizedPath;
+use zccache_core::{config::CACHE_TEST_BINS_ENV, NormalizedPath};
 
 // ─── Rustc detection tests ────────────────────────────────────────────
 
@@ -596,7 +596,7 @@ fn rustc_comma_separated_crate_type_equals_form() {
 //
 // These drive `parse_rustc_invocation_with_policy` rather than
 // `parse_invocation` so the policy value is explicit in each case. The env
-// read is the one-line `owned_env_flag_enabled(CACHE_TEST_BINS_ENV)` call that
+// read is the typed `cache_test_binaries_enabled()` accessor that
 // feeds this seam; keeping it out of the assertions means no test has to
 // mutate process-global environment state that the rest of the suite races on.
 

--- a/crates/zccache-core/src/config/env_policy.rs
+++ b/crates/zccache-core/src/config/env_policy.rs
@@ -1,0 +1,195 @@
+//! Registered environment-variable policy for zccache-owned boolean switches.
+//!
+//! This deliberately covers only the coherent `{1, true}` family. Foreign
+//! variables retain their denylist semantics, parsing errors remain errors,
+//! and diagnostic presence switches remain presence based; those are separate
+//! policies and must not be normalized accidentally.
+
+use std::ffi::OsStr;
+
+/// Value policy for a registered environment variable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum EnvironmentVariableKind {
+    /// A zccache-owned boolean: only `1` or case-insensitive `true` enables.
+    OwnedBoolean,
+}
+
+/// One registered zccache environment variable and its documented policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct EnvironmentVariableDeclaration {
+    /// Stable environment-variable name.
+    pub name: &'static str,
+    /// How this variable's value is interpreted.
+    pub kind: EnvironmentVariableKind,
+    /// Concise operator-facing purpose.
+    pub help: &'static str,
+}
+
+/// Set this to bypass zccache completely for one process invocation.
+const ZCCACHE_DISABLE_ENV: &str = "ZCCACHE_DISABLE";
+/// Set this in an embedding host to forbid standalone daemon launches.
+pub const NO_SPAWN_ENV: &str = "ZCCACHE_NO_SPAWN";
+/// Set this to run cheap compiler probes without an IPC round trip.
+const ZCCACHE_PROBE_BYPASS_ENV: &str = "ZCCACHE_PROBE_BYPASS";
+/// Set this to allow caching Rust `--test` harness links.
+pub const CACHE_TEST_BINS_ENV: &str = "ZCCACHE_CACHE_TEST_BINS";
+
+/// The complete registry for the owned-boolean policy family.
+///
+/// New entries require a typed accessor below. The `ban_registered_env_read`
+/// Dylint rejects direct `std::env::{var,var_os}` reads of these names outside
+/// this owner, preserving one parser and one lookup point per policy.
+pub const ENVIRONMENT_VARIABLES: &[EnvironmentVariableDeclaration] = &[
+    EnvironmentVariableDeclaration {
+        name: ZCCACHE_DISABLE_ENV,
+        kind: EnvironmentVariableKind::OwnedBoolean,
+        help: "Bypass zccache and run the compiler directly.",
+    },
+    EnvironmentVariableDeclaration {
+        name: NO_SPAWN_ENV,
+        kind: EnvironmentVariableKind::OwnedBoolean,
+        help: "Forbid standalone zccache daemon launches from an embedding host.",
+    },
+    EnvironmentVariableDeclaration {
+        name: ZCCACHE_PROBE_BYPASS_ENV,
+        kind: EnvironmentVariableKind::OwnedBoolean,
+        help: "Run cheap compiler probes without using the cache daemon.",
+    },
+    EnvironmentVariableDeclaration {
+        name: CACHE_TEST_BINS_ENV,
+        kind: EnvironmentVariableKind::OwnedBoolean,
+        help: "Opt into caching Rust test-harness links.",
+    },
+];
+
+#[derive(Debug, Clone, Copy)]
+enum OwnedBoolean {
+    Disable,
+    NoSpawn,
+    ProbeBypass,
+    CacheTestBinaries,
+}
+
+impl OwnedBoolean {
+    const fn name(self) -> &'static str {
+        match self {
+            Self::Disable => ZCCACHE_DISABLE_ENV,
+            Self::NoSpawn => NO_SPAWN_ENV,
+            Self::ProbeBypass => ZCCACHE_PROBE_BYPASS_ENV,
+            Self::CacheTestBinaries => CACHE_TEST_BINS_ENV,
+        }
+    }
+
+    fn enabled(self) -> bool {
+        if matches!(self, Self::NoSpawn) {
+            return no_spawn_from_env_value(std::env::var_os(self.name()).as_deref());
+        }
+        owned_flag_enabled(std::env::var(self.name()).ok().as_deref())
+    }
+}
+
+/// The canonical grammar for a zccache-owned boolean switch: `1` or
+/// case-insensitive `true` enables it; every other value, including an
+/// unrecognised one, is disabled. Whitespace around a valid value is ignored.
+#[must_use]
+pub fn owned_flag_enabled(value: Option<&str>) -> bool {
+    value.is_some_and(|raw| {
+        let trimmed = raw.trim();
+        trimmed == "1" || trimmed.eq_ignore_ascii_case("true")
+    })
+}
+
+/// Applies [`owned_flag_enabled`] to an environment variable by name.
+///
+/// This compatibility shim preserves the former public
+/// `zccache::core::config::owned_env_flag_enabled` API. New internal callers
+/// must use the typed accessor for their registered setting so the registry
+/// remains the sole owner of lookup and parsing policy.
+#[deprecated(
+    note = "use the typed zccache_core::config accessor for the registered environment variable"
+)]
+#[must_use]
+pub fn owned_env_flag_enabled(name: &str) -> bool {
+    owned_flag_enabled(std::env::var(name).ok().as_deref())
+}
+
+/// True when `ZCCACHE_DISABLE` bypasses the cache for this process.
+#[must_use]
+pub fn zccache_disabled() -> bool {
+    OwnedBoolean::Disable.enabled()
+}
+
+/// True when the host forbids standalone daemon spawns via [`NO_SPAWN_ENV`].
+#[must_use]
+pub fn daemon_spawn_disabled() -> bool {
+    OwnedBoolean::NoSpawn.enabled()
+}
+
+/// True when `ZCCACHE_PROBE_BYPASS` opts cheap probes out of the daemon path.
+#[must_use]
+pub fn probe_bypass_enabled() -> bool {
+    OwnedBoolean::ProbeBypass.enabled()
+}
+
+/// True when `ZCCACHE_CACHE_TEST_BINS` re-admits Rust `--test` harness links.
+#[must_use]
+pub fn cache_test_binaries_enabled() -> bool {
+    OwnedBoolean::CacheTestBinaries.enabled()
+}
+
+/// Testable core of [`daemon_spawn_disabled`] — no environment access.
+#[must_use]
+pub(crate) fn no_spawn_from_env_value(value: Option<&OsStr>) -> bool {
+    owned_flag_enabled(value.map(|value| value.to_string_lossy()).as_deref())
+}
+
+/// Standard error for a refused spawn. Names [`NO_SPAWN_ENV`] so operators
+/// can find the knob, and points at the embedded service so the failure is
+/// self-explaining in host contexts.
+#[must_use]
+pub fn no_spawn_error(daemon_name: &str) -> String {
+    format!(
+        "{daemon_name} spawn disabled by host ({NO_SPAWN_ENV}=1); \
+         this host serves compiles through an embedded zccache service"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_contains_only_owned_boolean_switches() {
+        assert_eq!(ENVIRONMENT_VARIABLES.len(), 4);
+        assert!(ENVIRONMENT_VARIABLES
+            .iter()
+            .all(|declaration| { declaration.kind == EnvironmentVariableKind::OwnedBoolean }));
+    }
+
+    #[test]
+    fn registry_names_are_unique() {
+        for (index, declaration) in ENVIRONMENT_VARIABLES.iter().enumerate() {
+            assert!(
+                ENVIRONMENT_VARIABLES[..index]
+                    .iter()
+                    .all(|previous| previous.name != declaration.name),
+                "duplicate registered environment variable: {}",
+                declaration.name,
+            );
+        }
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn compatibility_accessor_keeps_the_former_dynamic_lookup() {
+        const COMPATIBILITY_TEST_ENV: &str = "ZCCACHE_ISSUE_1478_COMPATIBILITY_TEST";
+
+        std::env::remove_var(COMPATIBILITY_TEST_ENV);
+        assert!(!owned_env_flag_enabled(COMPATIBILITY_TEST_ENV));
+
+        std::env::set_var(COMPATIBILITY_TEST_ENV, " true ");
+        assert!(owned_env_flag_enabled(COMPATIBILITY_TEST_ENV));
+
+        std::env::remove_var(COMPATIBILITY_TEST_ENV);
+    }
+}

--- a/crates/zccache-core/src/config/mod.rs
+++ b/crates/zccache-core/src/config/mod.rs
@@ -8,6 +8,7 @@
 //! unchanged once the root crate re-exports `zccache_core` as `core`.
 
 pub mod cleanup;
+mod env_policy;
 pub mod namespace;
 pub mod paths;
 pub mod resolve;
@@ -60,73 +61,6 @@ pub const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 3600;
 /// without falling back to byte-copy. Unset → behaviour unchanged.
 pub const COLOCATE_ENV: &str = "ZCCACHE_COLOCATE";
 
-/// Environment variable set by embedding hosts (e.g. soldr's compiled-in
-/// `zccache` trampoline, which serves compiles through an embedded
-/// in-process zccache service) to forbid the CLI from ever spawning a
-/// standalone `zccache-daemon` / `zccache-download-daemon` process
-/// (issue #982). Value grammar matches `ZCCACHE_DISABLE`: `1` or
-/// case-insensitive `true`. Connecting to an already-running,
-/// version-compatible daemon remains allowed — the guard forbids
-/// spawning, not talking.
-pub const NO_SPAWN_ENV: &str = "ZCCACHE_NO_SPAWN";
-
-/// The canonical grammar for a zccache-**owned** boolean switch: `1` or
-/// case-insensitive `true` enables it; everything else — unset, empty, `0`,
-/// `false`, or any unrecognised value — leaves it disabled.
-///
-/// Unknown values must read as *disabled*, not enabled. Most of these knobs
-/// are named `*_DISABLE` / `*_NO_*`, so a permissive parser would let a typo
-/// turn the cache off. That is the opposite convention from a *foreign*
-/// variable whose value space we do not own (`CI`, `GITHUB_ACTIONS`), where
-/// presence with an unrecognised value is normally meant as "on" — those go
-/// through the denylist parser in `daemon::process`, not this one.
-///
-/// The value is trimmed. Environment variables acquire stray whitespace very
-/// easily (CI YAML, `set VAR=1 ` on Windows), and `ZCCACHE_DISABLE` is the
-/// documented emergency bypass — it silently doing nothing because of a
-/// trailing space is exactly the failure an operator cannot afford there.
-///
-/// Issue #1478: this grammar was previously written out three times as an
-/// inline expression, so nothing kept the copies in agreement.
-#[must_use]
-pub fn owned_flag_enabled(value: Option<&str>) -> bool {
-    value.is_some_and(|raw| {
-        let trimmed = raw.trim();
-        trimmed == "1" || trimmed.eq_ignore_ascii_case("true")
-    })
-}
-
-/// [`owned_flag_enabled`] applied to an environment variable.
-#[must_use]
-pub fn owned_env_flag_enabled(name: &str) -> bool {
-    owned_flag_enabled(std::env::var(name).ok().as_deref())
-}
-
-/// True when the host forbids standalone daemon spawns via [`NO_SPAWN_ENV`].
-#[must_use]
-pub fn daemon_spawn_disabled() -> bool {
-    no_spawn_from_env_value(std::env::var_os(NO_SPAWN_ENV).as_deref())
-}
-
-/// Testable core of [`daemon_spawn_disabled`] — no environment access.
-#[must_use]
-pub(crate) fn no_spawn_from_env_value(value: Option<&std::ffi::OsStr>) -> bool {
-    // One grammar, three former copies (#1478). OsStr -> str first.
-    let value = value.map(|v| v.to_string_lossy());
-    owned_flag_enabled(value.as_deref())
-}
-
-/// Standard error for a refused spawn. Names [`NO_SPAWN_ENV`] so operators
-/// can find the knob, and points at the embedded service so the failure is
-/// self-explaining in host contexts.
-#[must_use]
-pub fn no_spawn_error(daemon_name: &str) -> String {
-    format!(
-        "{daemon_name} spawn disabled by host ({NO_SPAWN_ENV}=1); \
-         this host serves compiles through an embedded zccache service"
-    )
-}
-
 // ---------------------------------------------------------------------------
 // Re-exports - every public symbol the old single-file module exposed.
 // Facade callers use `zccache::core::config::<Name>`, so we keep that path
@@ -134,6 +68,13 @@ pub fn no_spawn_error(daemon_name: &str) -> String {
 // ---------------------------------------------------------------------------
 
 pub use cleanup::{cleanup_legacy_temp_root_state, cleanup_stale_depfile_dirs};
+#[allow(deprecated)]
+pub use env_policy::owned_env_flag_enabled;
+pub use env_policy::{
+    cache_test_binaries_enabled, daemon_spawn_disabled, no_spawn_error, owned_flag_enabled,
+    probe_bypass_enabled, zccache_disabled, EnvironmentVariableDeclaration,
+    EnvironmentVariableKind, CACHE_TEST_BINS_ENV, ENVIRONMENT_VARIABLES, NO_SPAWN_ENV,
+};
 pub use namespace::{
     daemon_namespace, daemon_namespace_label, sanitize_daemon_namespace, sanitize_ipc_component,
 };

--- a/crates/zccache-core/src/config/tests.rs
+++ b/crates/zccache-core/src/config/tests.rs
@@ -828,7 +828,7 @@ fn colocate_basename_appears_in_path() {
 
 #[test]
 fn no_spawn_value_grammar_matches_zccache_disable() {
-    use super::no_spawn_from_env_value;
+    use super::env_policy::no_spawn_from_env_value;
     use std::ffi::OsStr;
 
     assert!(no_spawn_from_env_value(Some(OsStr::new("1"))));
@@ -910,7 +910,7 @@ fn an_owned_flag_tolerates_surrounding_whitespace() {
 
 #[test]
 fn no_spawn_really_shares_the_owned_flag_grammar() {
-    use super::{no_spawn_from_env_value, owned_flag_enabled};
+    use super::{env_policy::no_spawn_from_env_value, owned_flag_enabled};
     use std::ffi::OsStr;
 
     // `no_spawn_value_grammar_matches_zccache_disable` asserts a *cross-variable*

--- a/dylints/ban_registered_env_read/Cargo.toml
+++ b/dylints/ban_registered_env_read/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "ban_registered_env_read"
+version = "0.1.0"
+description = "Require registered zccache environment variables to use typed accessors"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+dylint_linting = "=6.0.3"
+
+[dev-dependencies]
+dylint_testing = "=6.0.3"
+
+[package.metadata.rust-analyzer]
+rustc_private = true
+
+[workspace]

--- a/dylints/ban_registered_env_read/README.md
+++ b/dylints/ban_registered_env_read/README.md
@@ -1,0 +1,13 @@
+# ban_registered_env_read
+
+Requires the registered zccache-owned boolean switches to be read through
+their typed accessors in `zccache_core::config`. The policy registry owns the
+allowlist grammar (`1` or `true`; unknown values are false), so direct
+`std::env::var` / `var_os` reads would allow parser and lookup policy to drift.
+
+The lint deliberately covers only the names in this coherent registry. It does
+not rewrite the workspace's unrelated environment access, foreign-variable
+denylist handling, strict parsers whose unknown values are errors, or
+presence-only diagnostics.
+
+`crates/zccache-core/src/config/env_policy.rs` is the sole lookup owner.

--- a/dylints/ban_registered_env_read/rust-toolchain.toml
+++ b/dylints/ban_registered_env_read/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly-2026-05-26"
+components = ["llvm-tools-preview", "rust-src", "rustc-dev"]

--- a/dylints/ban_registered_env_read/src/README.md
+++ b/dylints/ban_registered_env_read/src/README.md
@@ -1,0 +1,7 @@
+# Source
+
+The lint matches resolved `std::env::var` and `std::env::var_os` calls whose
+literal or resolved `&str` constant argument evaluates to a registered
+owned-boolean name. Evaluating the value follows re-exports and local aliases
+without mistaking an unrelated same-named constant for policy. The policy owner
+is the only production source excluded from the rule.

--- a/dylints/ban_registered_env_read/src/lib.rs
+++ b/dylints/ban_registered_env_read/src/lib.rs
@@ -1,0 +1,215 @@
+#![feature(rustc_private)]
+
+extern crate rustc_ast;
+extern crate rustc_errors;
+extern crate rustc_hir;
+extern crate rustc_middle;
+extern crate rustc_span;
+
+use rustc_ast::LitKind;
+use rustc_errors::DiagDecorator;
+use rustc_hir::def::Res;
+use rustc_hir::{Expr, ExprKind};
+use rustc_lint::{LateContext, LateLintPass, LintContext};
+use rustc_middle::ty;
+use rustc_span::{symbol::Symbol, FileName, RemapPathScopeComponents, Span};
+
+dylint_linting::declare_late_lint! {
+    /// ### What it does
+    ///
+    /// Bans direct `std::env::var` and `std::env::var_os` reads of the
+    /// zccache-owned booleans registered in
+    /// `zccache_core::config::ENVIRONMENT_VARIABLES`.
+    ///
+    /// ### Why is this bad?
+    ///
+    /// Each registered name has an intentionally strict allowlist grammar:
+    /// `1` and `true` enable it; unknown values are disabled. Reading one at
+    /// a call site invites a second parser or a raw presence check, which can
+    /// silently invert a `*_DISABLE` or `*_NO_*` switch.
+    ///
+    /// ### Example
+    ///
+    /// ```rust,ignore
+    /// let disabled = std::env::var("ZCCACHE_DISABLE").is_ok();
+    /// ```
+    ///
+    /// Use the typed accessor instead:
+    ///
+    /// ```rust,ignore
+    /// let disabled = zccache_core::config::zccache_disabled();
+    /// ```
+    pub BAN_REGISTERED_ENV_READ,
+    Deny,
+    "read registered zccache environment variables through their typed policy accessors"
+}
+
+const REGISTERED_NAMES: &[&str] = &[
+    "ZCCACHE_DISABLE",
+    "ZCCACHE_NO_SPAWN",
+    "ZCCACHE_PROBE_BYPASS",
+    "ZCCACHE_CACHE_TEST_BINS",
+];
+const POLICY_OWNER: &str = "crates/zccache-core/src/config/env_policy.rs";
+const RAW_ENV_FUNCTIONS: &[&[&str]] = &[&["std", "env", "var"], &["std", "env", "var_os"]];
+
+impl<'tcx> LateLintPass<'tcx> for BanRegisteredEnvRead {
+    fn check_expr(&mut self, cx: &LateContext<'tcx>, expr: &'tcx Expr<'tcx>) {
+        let ExprKind::Call(callee, arguments) = expr.kind else {
+            return;
+        };
+        let Some(name) = registered_read_name(cx, callee, arguments) else {
+            return;
+        };
+        if is_policy_owner(&source_filename(cx, expr.span)) {
+            return;
+        }
+        cx.opt_span_lint(
+            BAN_REGISTERED_ENV_READ,
+            Some(expr.span),
+            DiagDecorator(move |diag| {
+                diag.primary_message(format!(
+                    "`{name}` is registered environment policy; use its typed \
+                     zccache_core::config accessor instead of std::env::var"
+                ));
+            }),
+        );
+    }
+}
+
+fn registered_read_name<'tcx>(
+    cx: &LateContext<'tcx>,
+    callee: &'tcx Expr<'tcx>,
+    arguments: &'tcx [Expr<'tcx>],
+) -> Option<&'static str> {
+    let ExprKind::Path(qpath) = callee.kind else {
+        return None;
+    };
+    let Res::Def(_, def_id) = cx.qpath_res(&qpath, callee.hir_id) else {
+        return None;
+    };
+    if !RAW_ENV_FUNCTIONS
+        .iter()
+        .any(|path| path_ends_with(&cx.get_def_path(def_id), path))
+    {
+        return None;
+    }
+    let Some(argument) = arguments.first() else {
+        return None;
+    };
+    match argument.kind {
+        ExprKind::Lit(literal) => {
+            let LitKind::Str(value, _) = literal.node else {
+                return None;
+            };
+            REGISTERED_NAMES
+                .iter()
+                .copied()
+                .find(|registered| *registered == value.as_str())
+        }
+        ExprKind::Path(qpath) => {
+            let Res::Def(_, def_id) = cx.qpath_res(&qpath, argument.hir_id) else {
+                return None;
+            };
+            registered_constant_value(cx, argument, def_id)
+        }
+        _ => None,
+    }
+}
+
+/// Resolves a constant argument to its string value instead of trusting its
+/// final path segment. This follows re-exports and local aliases while
+/// avoiding false positives for unrelated constants with familiar names.
+fn registered_constant_value<'tcx>(
+    cx: &LateContext<'tcx>,
+    argument: &'tcx Expr<'tcx>,
+    def_id: rustc_hir::def_id::DefId,
+) -> Option<&'static str> {
+    if !matches!(
+        cx.typeck_results().expr_ty(argument).peel_refs().kind(),
+        ty::Str
+    ) {
+        return None;
+    }
+    let value = cx.tcx.const_eval_poly(def_id).ok()?;
+    let bytes = value.try_get_slice_bytes_for_diagnostics(cx.tcx)?;
+    let value = std::str::from_utf8(bytes).ok()?;
+    REGISTERED_NAMES
+        .iter()
+        .copied()
+        .find(|registered| *registered == value)
+}
+
+fn path_ends_with(path: &[Symbol], expected: &[&str]) -> bool {
+    path.len() >= expected.len()
+        && path[path.len() - expected.len()..]
+            .iter()
+            .zip(expected)
+            .all(|(actual, expected)| *actual == Symbol::intern(expected))
+}
+
+fn is_policy_owner(filename: &str) -> bool {
+    normalize_slashes(filename).ends_with(POLICY_OWNER)
+}
+
+fn source_filename(cx: &LateContext<'_>, span: Span) -> String {
+    match cx.sess().source_map().span_to_filename(span) {
+        FileName::Real(real_filename) => real_filename
+            .local_path()
+            .map(|path| path.to_string_lossy().into_owned())
+            .unwrap_or_else(|| {
+                real_filename
+                    .path(RemapPathScopeComponents::DIAGNOSTICS)
+                    .to_string_lossy()
+                    .into_owned()
+            }),
+        filename => filename
+            .display(RemapPathScopeComponents::DIAGNOSTICS)
+            .to_string(),
+    }
+}
+
+fn normalize_slashes(path: &str) -> String {
+    path.replace('\\', "/")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{is_policy_owner, REGISTERED_NAMES};
+
+    #[test]
+    fn registered_names_are_unique() {
+        for (index, name) in REGISTERED_NAMES.iter().enumerate() {
+            assert!(
+                REGISTERED_NAMES[..index]
+                    .iter()
+                    .all(|previous| previous != name),
+                "duplicate registered environment variable: {name}",
+            );
+        }
+    }
+
+    #[test]
+    fn policy_owner_exemption_normalizes_paths() {
+        for filename in [
+            "crates/zccache-core/src/config/env_policy.rs",
+            "/workspace/zccache/crates/zccache-core/src/config/env_policy.rs",
+            r"C:\workspace\zccache\crates\zccache-core\src\config\env_policy.rs",
+        ] {
+            assert!(is_policy_owner(filename), "expected owner path: {filename}");
+        }
+        assert!(!is_policy_owner(
+            "crates/zccache-core/src/config/env_policy.rs.bak"
+        ));
+    }
+}
+
+#[cfg(test)]
+mod ui_test_support {
+    include!("../../ui_test_support.rs");
+}
+
+#[test]
+fn ui() {
+    ui_test_support::run(env!("CARGO_PKG_NAME"), env!("CARGO_MANIFEST_DIR"));
+}

--- a/dylints/ban_registered_env_read/ui/README.md
+++ b/dylints/ban_registered_env_read/ui/README.md
@@ -1,0 +1,5 @@
+# UI fixtures
+
+`disallowed.rs` covers literal, registered-constant, and aliased-constant raw
+reads. Its adjacent `.stderr` snapshot is the diagnostic contract; an
+unrelated same-named constant is intentionally accepted.

--- a/dylints/ban_registered_env_read/ui/disallowed.rs
+++ b/dylints/ban_registered_env_read/ui/disallowed.rs
@@ -1,0 +1,15 @@
+mod zccache_core {
+    pub mod config {
+        pub const CACHE_TEST_BINS_ENV: &str = "ZCCACHE_CACHE_TEST_BINS";
+    }
+}
+
+const LOCAL_ALIAS: &str = zccache_core::config::CACHE_TEST_BINS_ENV;
+const CACHE_TEST_BINS_ENV: &str = "ZCCACHE_NOT_REGISTERED";
+
+fn main() {
+    let _ = std::env::var("ZCCACHE_DISABLE");
+    let _ = std::env::var_os(zccache_core::config::CACHE_TEST_BINS_ENV);
+    let _ = std::env::var(LOCAL_ALIAS);
+    let _ = std::env::var(CACHE_TEST_BINS_ENV);
+}

--- a/dylints/ban_registered_env_read/ui/disallowed.stderr
+++ b/dylints/ban_registered_env_read/ui/disallowed.stderr
@@ -1,0 +1,22 @@
+error: `ZCCACHE_DISABLE` is registered environment policy; use its typed zccache_core::config accessor instead of std::env::var
+  --> $DIR/disallowed.rs:11:13
+   |
+LL |     let _ = std::env::var("ZCCACHE_DISABLE");
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: `#[deny(ban_registered_env_read)]` on by default
+
+error: `ZCCACHE_CACHE_TEST_BINS` is registered environment policy; use its typed zccache_core::config accessor instead of std::env::var
+  --> $DIR/disallowed.rs:12:13
+   |
+LL |     let _ = std::env::var_os(zccache_core::config::CACHE_TEST_BINS_ENV);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: `ZCCACHE_CACHE_TEST_BINS` is registered environment policy; use its typed zccache_core::config accessor instead of std::env::var
+  --> $DIR/disallowed.rs:13:13
+   |
+LL |     let _ = std::env::var(LOCAL_ALIAS);
+   |             ^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: aborting due to 3 previous errors
+


### PR DESCRIPTION
## Summary

- register the four zccache-owned boolean switches in one facade-owned declaration table and route internal reads through typed accessors
- preserve the deliberate foreign-variable, strict-parser, and presence-only semantics, plus retain the former dynamic helper as a deprecated compatibility shim
- add a Dylint that rejects direct registered reads outside the policy owner, including literals and resolved constant aliases, with CI wiring and cross-platform owner-path handling

## Validation

- `soldr cargo fmt --all --check`
- `soldr cargo fmt --manifest-path dylints/ban_registered_env_read/Cargo.toml --all -- --check`
- zccache-core config tests: 71 passed
- zccache-compiler rustc tests: 38 passed
- Python Dylint wiring tests: 15 passed
- standalone Dylint: 2 unit tests and 1 UI fixture passed, 0 ignored
- full ten-library workspace Dylint sweep: exit 0
- `soldr cargo check --workspace --all-targets`
- independent `clud-review`: clean

Closes #1478
