### PR TITLE
feat(embedded): retain host admission leases through compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4147,7 +4147,7 @@ dependencies = [
 
 [[package]]
 name = "zccache"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4222,7 +4222,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-artifact"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "blake3",
@@ -4247,7 +4247,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-audit"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -4257,7 +4257,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4266,7 +4266,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-cli-core"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "blake3",
@@ -4320,14 +4320,14 @@ dependencies = [
 
 [[package]]
 name = "zccache-compile-trace"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "zccache-audit",
 ]
 
 [[package]]
 name = "zccache-compiler"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "clang",
  "serde_json",
@@ -4340,7 +4340,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-core"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "crash-handler",
  "dashmap",
@@ -4354,7 +4354,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-daemon-core"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "arc-swap",
  "bincode",
@@ -4405,7 +4405,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-depgraph"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "blake3",
@@ -4427,7 +4427,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "blake3",
  "futures",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-download-protocol"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "bytes",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "filetime",
  "fs2",
@@ -4473,7 +4473,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fingerprint-py"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-fscache"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "dashmap",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-gha"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "reqwest",
  "serde",
@@ -4510,7 +4510,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-hash"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "blake3",
  "memmap2",
@@ -4520,7 +4520,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-ipc"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "blake3",
  "bytes",
@@ -4542,7 +4542,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-platform"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "crash-handler",
  "interprocess",
@@ -4554,7 +4554,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-protocol"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "bincode",
  "bytes",
@@ -4572,7 +4572,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-symbols"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "tempfile",
  "zccache-core",
@@ -4580,7 +4580,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-test-support"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "tempfile",
  "zccache-audit",
@@ -4589,7 +4589,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "globset",
  "jwalk",
@@ -4604,7 +4604,7 @@ dependencies = [
 
 [[package]]
 name = "zccache-watcher-py"
-version = "1.13.19"
+version = "1.13.20"
 dependencies = [
  "pyo3",
  "pyo3-build-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "1.13.19"
+version = "1.13.20"
 edition = "2021"
 rust-version = "1.95.0"
 license = "AGPL-3.0-only"

--- a/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compile_resource_gate.rs
@@ -9,7 +9,9 @@
 //! bounded compiler slot is returned, so post-compiler work cannot overlap a
 //! queued exclusive unit.
 
+use std::future::Future;
 use std::path::Path;
+use std::pin::Pin;
 use std::sync::Arc;
 
 use tokio::sync::{OwnedRwLockReadGuard, OwnedRwLockWriteGuard, RwLock};
@@ -90,6 +92,32 @@ pub trait HostAdmissionClassifier: Send + Sync + 'static {
         &self,
         request: &HostCompilerRequest<'_>,
     ) -> Result<bool, HostAdmissionError>;
+
+    /// Acquire host-owned admission after cache-hit classification and before
+    /// zccache's canonical compiler gates. The returned permit is retained
+    /// through compiler exit. Existing classifiers remain no-op by default.
+    fn acquire<'a>(
+        &'a self,
+        _request: HostCompilerRequest<'a>,
+    ) -> Pin<Box<dyn Future<Output = Result<HostAdmissionPermit, HostAdmissionError>> + Send + 'a>>
+    {
+        Box::pin(async { Ok(HostAdmissionPermit::default()) })
+    }
+}
+
+/// Type-erased host resource lease retained through compiler exit.
+#[derive(Default)]
+pub struct HostAdmissionPermit {
+    _guard: Option<Box<dyn Send + Sync + 'static>>,
+}
+
+impl HostAdmissionPermit {
+    #[must_use]
+    pub fn new(guard: impl Send + Sync + 'static) -> Self {
+        Self {
+            _guard: Some(Box::new(guard)),
+        }
+    }
 }
 
 /// Fair shared/exclusive admission around real compiler execution.
@@ -115,6 +143,7 @@ pub(super) enum CompileResourcePermit {
 pub(super) struct CompilerAdmission {
     _resource: CompileResourcePermit,
     _compile: super::compile_progress::CompileGateGuard,
+    _host: HostAdmissionPermit,
 }
 
 impl CompilerAdmission {
@@ -124,8 +153,10 @@ impl CompilerAdmission {
         let Self {
             _resource: resource,
             _compile: compile,
+            _host: host,
         } = self;
         drop(compile);
+        drop(host);
         resource
     }
 }
@@ -147,6 +178,7 @@ impl CompileResourceGate {
 pub(super) async fn acquire_compiler_admission(
     state: &SharedState,
     exclusive: bool,
+    host: HostAdmissionPermit,
 ) -> (CompilerAdmission, Option<usize>) {
     let (compile, available_before) = super::compile_progress::acquire_compile_gate(
         state.compile_concurrency.as_ref(),
@@ -158,6 +190,7 @@ pub(super) async fn acquire_compiler_admission(
         CompilerAdmission {
             _resource: resource,
             _compile: compile,
+            _host: host,
         },
         available_before,
     )
@@ -285,18 +318,24 @@ pub(super) fn requires_exclusive_access_for_misses<'a>(
 /// Every caller reaches this only after cache-hit classification. The policy
 /// has no effect when absent, and the result still feeds the single canonical
 /// semaphore-then-RwLock admission helper below.
-pub(super) fn requires_exclusive_admission(
+pub(super) async fn host_admission(
     state: &SharedState,
     family: CompilerFamily,
     args: &[String],
     source: Option<&Path>,
     built_in: bool,
-) -> Result<bool, HostAdmissionError> {
-    combines_exclusive_admission(
+) -> Result<(bool, HostAdmissionPermit), HostAdmissionError> {
+    let request = HostCompilerRequest::new(family, args, source);
+    let exclusive = combines_exclusive_admission(
         built_in,
         state.host_admission_classifier.as_deref(),
         HostCompilerRequest::new(family, args, source),
-    )
+    )?;
+    let permit = match state.host_admission_classifier.as_deref() {
+        Some(classifier) => classifier.acquire(request).await?,
+        None => HostAdmissionPermit::default(),
+    };
+    Ok((exclusive, permit))
 }
 
 fn combines_exclusive_admission(
@@ -576,13 +615,26 @@ mod tests {
         let (compile, _) =
             crate::daemon::server::compile_progress::acquire_compile_gate(Some(&semaphore), &queue)
                 .await;
+        struct DropProbe(Arc<std::sync::atomic::AtomicBool>);
+        impl Drop for DropProbe {
+            fn drop(&mut self) {
+                self.0.store(false, std::sync::atomic::Ordering::SeqCst);
+            }
+        }
+        let host_live = Arc::new(std::sync::atomic::AtomicBool::new(true));
         let admission = CompilerAdmission {
             _resource: resource_gate.acquire(false).await,
             _compile: compile,
+            _host: HostAdmissionPermit::new(DropProbe(Arc::clone(&host_live))),
         };
 
         assert_eq!(semaphore.available_permits(), 0);
+        assert!(host_live.load(std::sync::atomic::Ordering::SeqCst));
         let resource = admission.release_compiler_slot();
+        assert!(
+            !host_live.load(std::sync::atomic::Ordering::SeqCst),
+            "host lease must drop at compiler exit"
+        );
         assert_eq!(
             semaphore.available_permits(),
             1,
@@ -687,7 +739,7 @@ mod tests {
             ),
         ] {
             assert!(
-                source.contains("requires_exclusive_admission("),
+                source.contains("host_admission("),
                 "{name} compiler path bypasses the host policy"
             );
             assert!(

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile/pipeline/compile_exec.rs
@@ -287,23 +287,30 @@ pub(super) async fn run_compile_exec(req: CompileExecRequest<'_>) -> CompileExec
             effective_args,
             source_path.as_path(),
         );
-    let exclusive = match crate::daemon::server::compile_resource_gate::requires_exclusive_admission(
-        state,
-        compilation.family,
-        effective_args,
-        Some(source_path.as_path()),
-        built_in_exclusive,
-    ) {
-        Ok(exclusive) => exclusive,
-        Err(error) => {
-            return CompileExecResult::Error(Response::Error {
-                message: format!("host compiler-admission classification failed: {error}"),
-            });
-        }
-    };
+    let (exclusive, host_admission) =
+        match crate::daemon::server::compile_resource_gate::host_admission(
+            state,
+            compilation.family,
+            effective_args,
+            Some(source_path.as_path()),
+            built_in_exclusive,
+        )
+        .await
+        {
+            Ok(exclusive) => exclusive,
+            Err(error) => {
+                return CompileExecResult::Error(Response::Error {
+                    message: format!("host compiler admission failed: {error}"),
+                });
+            }
+        };
     let (compiler_admission, available_before) =
-        crate::daemon::server::compile_resource_gate::acquire_compiler_admission(state, exclusive)
-            .await;
+        crate::daemon::server::compile_resource_gate::acquire_compiler_admission(
+            state,
+            exclusive,
+            host_admission,
+        )
+        .await;
     if exclusive {
         tracing::info!(
             event = "compile_exclusive",

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_ephemeral.rs
@@ -150,22 +150,25 @@ pub(super) async fn run_compiler_direct_with_family(
     };
     let built_in_exclusive =
         super::compile_resource_gate::requires_exclusive_access_from_args(family_hint, args, cwd);
-    let exclusive = match super::compile_resource_gate::requires_exclusive_admission(
+    let (exclusive, host_admission) = match super::compile_resource_gate::host_admission(
         state,
         family_hint,
         args,
         None,
         built_in_exclusive,
-    ) {
+    )
+    .await
+    {
         Ok(exclusive) => exclusive,
         Err(error) => {
             return Response::Error {
-                message: format!("host compiler-admission classification failed: {error}"),
+                message: format!("host compiler admission failed: {error}"),
             };
         }
     };
     let (compiler_admission, _) =
-        super::compile_resource_gate::acquire_compiler_admission(state, exclusive).await;
+        super::compile_resource_gate::acquire_compiler_admission(state, exclusive, host_admission)
+            .await;
     if exclusive {
         tracing::info!(
             event = "compile_exclusive",

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi.rs
@@ -764,23 +764,30 @@ pub(super) async fn handle_compile_multi(
                 UnitCacheResult::Hit { .. } => None,
             }),
         );
-    let exclusive = match crate::daemon::server::compile_resource_gate::requires_exclusive_admission(
-        &state,
-        compilations[0].family,
-        &compiler_args,
-        None,
-        built_in_exclusive,
-    ) {
-        Ok(exclusive) => exclusive,
-        Err(error) => {
-            return Response::Error {
-                message: format!("host compiler-admission classification failed: {error}"),
-            };
-        }
-    };
+    let (exclusive, host_admission) =
+        match crate::daemon::server::compile_resource_gate::host_admission(
+            &state,
+            compilations[0].family,
+            &compiler_args,
+            None,
+            built_in_exclusive,
+        )
+        .await
+        {
+            Ok(exclusive) => exclusive,
+            Err(error) => {
+                return Response::Error {
+                    message: format!("host compiler admission failed: {error}"),
+                };
+            }
+        };
     let (compiler_admission, _) =
-        crate::daemon::server::compile_resource_gate::acquire_compiler_admission(&state, exclusive)
-            .await;
+        crate::daemon::server::compile_resource_gate::acquire_compiler_admission(
+            &state,
+            exclusive,
+            host_admission,
+        )
+        .await;
     let result =
         super::super::process::tokio_command_output_with_priority(&mut cmd, compiler_priority)
             .await;

--- a/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/handle_compile_multi_staged.rs
@@ -216,18 +216,20 @@ pub(super) async fn try_handle_staged_misses(
                 &compiler_args,
                 miss.source_path.as_path(),
             );
-        let exclusive =
-            match crate::daemon::server::compile_resource_gate::requires_exclusive_admission(
+        let (exclusive, host_admission) =
+            match crate::daemon::server::compile_resource_gate::host_admission(
                 state.as_ref(),
                 family,
                 &compiler_args,
                 Some(miss.source_path.as_path()),
                 built_in_exclusive,
-            ) {
+            )
+            .await
+            {
                 Ok(exclusive) => exclusive,
                 Err(error) => {
                     return Some(Response::Error {
-                        message: format!("host compiler-admission classification failed: {error}"),
+                        message: format!("host compiler admission failed: {error}"),
                     });
                 }
             };
@@ -242,6 +244,7 @@ pub(super) async fn try_handle_staged_misses(
                 crate::daemon::server::compile_resource_gate::acquire_compiler_admission(
                     &admission_state,
                     exclusive,
+                    host_admission,
                 )
                 .await;
             if let Some(available_before) = available_before {

--- a/crates/zccache-daemon-core/src/embedded.rs
+++ b/crates/zccache-daemon-core/src/embedded.rs
@@ -18,7 +18,7 @@ use crate::daemon::server::{
 
 pub use crate::audit::{AuditConfig, AuditContext, AuditEvent};
 pub use crate::daemon::server::compile_resource_gate::{
-    HostAdmissionClassifier, HostAdmissionError, HostCompilerRequest,
+    HostAdmissionClassifier, HostAdmissionError, HostAdmissionPermit, HostCompilerRequest,
 };
 pub use control::EmbeddedEventSink;
 

--- a/crates/zccache-daemon-core/src/embedded/admission_tests.rs
+++ b/crates/zccache-daemon-core/src/embedded/admission_tests.rs
@@ -8,6 +8,7 @@ use tempfile::TempDir;
 
 struct CountingHostPolicy {
     calls: Arc<AtomicUsize>,
+    acquires: Arc<AtomicUsize>,
 }
 
 impl HostAdmissionClassifier for CountingHostPolicy {
@@ -18,9 +19,28 @@ impl HostAdmissionClassifier for CountingHostPolicy {
         self.calls.fetch_add(1, Ordering::Relaxed);
         Ok(false)
     }
+
+    fn acquire<'a>(
+        &'a self,
+        _request: HostCompilerRequest<'a>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<
+                    Output = std::result::Result<HostAdmissionPermit, HostAdmissionError>,
+                > + Send
+                + 'a,
+        >,
+    > {
+        self.acquires.fetch_add(1, Ordering::Relaxed);
+        Box::pin(async { Ok(HostAdmissionPermit::default()) })
+    }
 }
 
-async fn start_service_with_policy(temp: &TempDir, calls: Arc<AtomicUsize>) -> ZccacheService {
+async fn start_service_with_policy(
+    temp: &TempDir,
+    calls: Arc<AtomicUsize>,
+    acquires: Arc<AtomicUsize>,
+) -> ZccacheService {
     let mut audit = AuditConfig::default();
     audit.mode = crate::audit::AuditMode::Off;
     ZccacheService::start_with_options_and_host_admission_classifier(
@@ -37,7 +57,7 @@ async fn start_service_with_policy(temp: &TempDir, calls: Arc<AtomicUsize>) -> Z
             cancellation: None,
         },
         ZccacheStartOptions::default(),
-        Arc::new(CountingHostPolicy { calls }),
+        Arc::new(CountingHostPolicy { calls, acquires }),
     )
     .await
     .expect("service start")
@@ -54,7 +74,8 @@ async fn host_policy_runs_for_a_miss_but_not_its_cache_hit() {
     std::fs::write(&source, "int admission_policy_unit(void) { return 1; }\n")
         .expect("source fixture");
     let calls = Arc::new(AtomicUsize::new(0));
-    let service = start_service_with_policy(&temp, Arc::clone(&calls)).await;
+    let acquires = Arc::new(AtomicUsize::new(0));
+    let service = start_service_with_policy(&temp, Arc::clone(&calls), Arc::clone(&acquires)).await;
     let request = CompileRequest {
         audit: AuditContext::new(
             crate::audit::AuditId::new("host-policy-run").expect("id"),
@@ -75,6 +96,7 @@ async fn host_policy_runs_for_a_miss_but_not_its_cache_hit() {
     let miss = service.compile(request.clone()).await.expect("cache miss");
     assert!(!miss.cached, "first compile must execute the compiler");
     assert_eq!(calls.load(Ordering::Relaxed), 1, "miss invokes policy once");
+    assert_eq!(acquires.load(Ordering::Relaxed), 1, "miss acquires once");
 
     std::fs::remove_file(&output).expect("remove cold output");
     let hit = service.compile(request).await.expect("cache hit");
@@ -83,6 +105,11 @@ async fn host_policy_runs_for_a_miss_but_not_its_cache_hit() {
         calls.load(Ordering::Relaxed),
         1,
         "cache hit must bypass the host policy and compiler admission"
+    );
+    assert_eq!(
+        acquires.load(Ordering::Relaxed),
+        1,
+        "cache hit must bypass host lease acquisition"
     );
     service
         .shutdown(ShutdownMode::Graceful)


### PR DESCRIPTION
Closes the embedded-host admission gap exposed by soldr#2878 and soldr#3024.

## Contract

- Preserve the existing synchronous shared/exclusive classifier.
- Add a backward-compatible async host lease hook with an empty default.
- Invoke it only after cache-hit classification.
- Retain its type-erased permit through real compiler exit on every compile path.
- Release the compiler-count slot and host lease together; retain the existing resource lock lifetime.

This lets embedded hosts account for resident non-compiler workloads without reducing global Cargo jobs, imposing a fixed compiler cap, or putting cache hits behind admission.

## Validation

- `soldr --no-cache cargo check -p zccache-daemon-core`
- `soldr --no-cache cargo test -p zccache-daemon-core --features test-support host_policy_runs_for_a_miss_but_not_its_cache_hit -- --nocapture`
- `soldr --no-cache cargo test -p zccache-daemon-core --features test-support compiler_slot_can_be_released_while_resource_admission_remains_live -- --nocapture`
- `soldr cargo fmt --all`
- `git diff --check`