### PR TITLE
fix(daemon): make staged-output materialization and child spawn mutually exclusive (ETXTBSY)

### DIFF
--- a/crates/zccache-daemon-core/src/daemon/mod.rs
+++ b/crates/zccache-daemon-core/src/daemon/mod.rs
@@ -33,6 +33,10 @@ pub mod log_sink;
 pub(crate) mod process;
 pub mod server;
 pub mod side_effect;
+/// Process-wide exclusion between staged-output materialization and child
+/// spawn so a forked child cannot inherit a write descriptor on an inode that
+/// is about to be executed (zccache#1562).
+pub(crate) mod spawn_exclusion;
 pub(crate) mod staged_stats;
 pub mod stats;
 pub mod trampoline;

--- a/crates/zccache-daemon-core/src/daemon/process.rs
+++ b/crates/zccache-daemon-core/src/daemon/process.rs
@@ -665,7 +665,7 @@ async fn tokio_command_output_with_priority_stdin_inner(
     }
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    let mut child = match running_process::spawn_tokio(cmd, owned_child_spawn_options()) {
+    let mut child = match spawn_tokio_excluding_materialization(cmd) {
         Ok(child) => child,
         Err(error) => return (Err(error), decision),
     };
@@ -702,10 +702,24 @@ pub(crate) async fn tokio_leaf_command_output_with_priority(
     cmd.stdin(Stdio::null());
     cmd.stdout(Stdio::piped());
     cmd.stderr(Stdio::piped());
-    let child = running_process::spawn_tokio(cmd, owned_child_spawn_options())?;
+    let child = spawn_tokio_excluding_materialization(cmd)?;
     attach_child_owner_death(&child);
     apply_priority_to_child(&child, priority);
     child.wait_with_output().await
+}
+
+/// Spawn a daemon-owned child while holding the shared half of the
+/// materialization/spawn lock (zccache#1562). `spawn` returns only after the
+/// child has exec'd (or failed to), so the guard covers the whole fork-to-exec
+/// window in which the child still holds a copy of this process's descriptor
+/// table. Holding it here, at the single choke point every compiler, linker,
+/// archiver, exec-tool, deploy-hook, and async identity-probe child passes
+/// through, keeps every call site covered without touching them.
+fn spawn_tokio_excluding_materialization(
+    cmd: &mut tokio::process::Command,
+) -> io::Result<tokio::process::Child> {
+    let _spawn_guard = crate::daemon::spawn_exclusion::spawn_shared();
+    running_process::spawn_tokio(cmd, owned_child_spawn_options())
 }
 
 fn attach_child_owner_death(child: &tokio::process::Child) {

--- a/crates/zccache-daemon-core/src/daemon/server/compiler_hash.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/compiler_hash.rs
@@ -89,6 +89,12 @@ struct ProbeOutput {
 fn output_within(cmd: std::process::Command, timeout: std::time::Duration) -> ProbeOutcome {
     const PROBE_OUTPUT_LIMIT: usize = 1024 * 1024;
 
+    // zccache#1562: running-process owns spawn *and* wait here, so the shared
+    // materialization/spawn guard has to bracket the whole bounded run rather
+    // than the spawn alone. A shared guard only blocks materialization (the
+    // exclusive side), never other spawns; this probe is a cold path taken
+    // once per compiler identity, normally ~10 ms, and bounded by `timeout`.
+    let _spawn_guard = crate::daemon::spawn_exclusion::spawn_shared();
     match running_process::run_std_command_bounded(cmd, Some(timeout), PROBE_OUTPUT_LIMIT) {
         Ok(output) => ProbeOutcome::Completed(ProbeOutput {
             success: output.exit_code == 0,

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/hook.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/hook.rs
@@ -9,6 +9,9 @@ use std::sync::{Mutex, OnceLock};
 pub(in crate::daemon::server) enum StagedHookPoint {
     PublicationStoreLocked,
     MaterializeOutput,
+    /// Inside the materialization copy window: the sibling temporary exists
+    /// and a write descriptor on it is still open (zccache#1562).
+    MaterializeTemporaryOpen,
     MaterializePublish,
     MaintenanceStoreLockPending,
 }

--- a/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
+++ b/crates/zccache-daemon-core/src/daemon/server/persist/staged_store/materialize.rs
@@ -77,9 +77,32 @@ pub(in crate::daemon::server) fn materialize_independent_with_stats(
         }
     }
 
+    // The copy lands in a unique sibling temporary that is renamed over the
+    // requested path, so readers never observe a partial output (#1563). That
+    // rename does NOT make the output safe to execute on its own: `rename(2)`
+    // keeps the inode, and a child forked by this process while the copy's
+    // write descriptor was open inherits that descriptor until its own
+    // `execve`. Cargo hard-links `build-script-build` to the published inode
+    // and execs it, and `ETXTBSY` is evaluated per inode, so the exec fails
+    // with `Text file busy` for the child's fork-to-exec window even though
+    // this process closed its descriptor before publishing (zccache#1562).
+    // The exclusive guard below keeps every daemon child spawn out of the
+    // open-write-close + rename window; see `daemon::spawn_exclusion`.
     let temporary = super::temporary_path(destination, "materialize");
     let result = (|| {
+        let _materialize_guard = crate::daemon::spawn_exclusion::materialize_exclusive();
         let (reflink, copy_bytes) = copy_output(source, &temporary)?;
+        #[cfg(test)]
+        {
+            // Test seam: keep a write descriptor on the temporary open while
+            // paused, modelling the descriptor `copy_output` holds mid-copy.
+            let open_for_write = fs::OpenOptions::new().write(true).open(&temporary)?;
+            super::hook::pause(
+                destination,
+                super::StagedHookPoint::MaterializeTemporaryOpen,
+            );
+            drop(open_for_write);
+        }
         #[cfg(test)]
         super::hook::pause(destination, super::StagedHookPoint::MaterializePublish);
         if fs::metadata(destination).is_ok() {
@@ -187,5 +210,77 @@ mod tests {
         hook.resume();
         materialize.join().unwrap().unwrap();
         assert_eq!(fs::read(&destination).unwrap(), b"new complete output");
+    }
+
+    /// zccache#1562: a child forked while the materialization copy held a
+    /// write descriptor on the sibling temporary inherits that descriptor
+    /// across the rename, so executing the published output fails with
+    /// `ETXTBSY` until the child execs. The spawn/materialize lock must keep
+    /// the fork out of the copy window. Disabling the exclusive guard in
+    /// `materialize_independent_with_stats` makes this test fail.
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn materialized_executable_runs_while_a_child_is_between_fork_and_exec() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::process::CommandExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("build_script_build-source");
+        let destination = dir.path().join("build-script-build");
+        fs::write(&source, b"#!/bin/sh\nexit 0\n").unwrap();
+        fs::set_permissions(&source, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let hook = StagedHookGuard::arm(&destination, StagedHookPoint::MaterializeTemporaryOpen);
+        let source_for_thread = source.clone();
+        let destination_for_thread = destination.clone();
+        let materialize = std::thread::spawn(move || {
+            materialize_independent_with_stats(&source_for_thread, &destination_for_thread)
+        });
+        hook.wait_until_reached();
+
+        // Another daemon task spawns a compiler child. Its fork-to-exec window
+        // is stretched to 500 ms so the inherited descriptor demonstrably
+        // outlives the rename below.
+        let spawner = std::thread::spawn(|| {
+            let mut cmd = tokio::process::Command::new("true");
+            // SAFETY: the closure only sleeps; it is async-signal-safe enough
+            // for a test and touches no locks or allocations.
+            unsafe {
+                cmd.as_std_mut().pre_exec(|| {
+                    std::thread::sleep(std::time::Duration::from_millis(500));
+                    Ok(())
+                });
+            }
+            let runtime = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap();
+            runtime.block_on(async {
+                crate::daemon::process::tokio_leaf_command_output_with_priority(
+                    &mut cmd,
+                    crate::daemon::process::CompilePriority::Normal,
+                )
+                .await
+            })
+        });
+        // Give the spawner time to reach the lock (or, without the lock, to
+        // fork while the temporary's write descriptor is still open).
+        std::thread::sleep(std::time::Duration::from_millis(100));
+
+        hook.resume();
+        materialize.join().unwrap().unwrap();
+
+        let status = std::process::Command::new(&destination)
+            .status()
+            .unwrap_or_else(|error| {
+                panic!(
+                    "published output {} must be executable immediately after \
+                     materialization returns: {error}",
+                    destination.display()
+                )
+            });
+        assert!(status.success());
+        let output = spawner.join().unwrap().unwrap();
+        assert!(output.status.success());
     }
 }

--- a/crates/zccache-daemon-core/src/daemon/spawn_exclusion.rs
+++ b/crates/zccache-daemon-core/src/daemon/spawn_exclusion.rs
@@ -1,0 +1,54 @@
+//! Mutual exclusion between staged-output materialization and child spawn
+//! (zackees/zccache#1562, zackees/soldr#3098).
+//!
+//! # The race
+//!
+//! A staged MISS is materialized by copying the private compiler output into a
+//! unique sibling temporary beside the requested path and then renaming that
+//! temporary over the requested path. The copy holds a write descriptor on the
+//! temporary's inode. The same daemon process spawns compiler children
+//! continuously, and on POSIX every `fork` duplicates the parent's descriptor
+//! table: a child forked while the copy's descriptor is open inherits that
+//! write descriptor and keeps it until its own `execve` closes it
+//! (`O_CLOEXEC` closes on exec, not on fork).
+//!
+//! `rename(2)` does not change the inode, so after the daemon closes its own
+//! descriptor and publishes the path the inherited copy is still a *writable
+//! descriptor on the published inode*. Cargo hard-links `build-script-build`
+//! to that inode and `execve`s it; `ETXTBSY` is evaluated against the inode,
+//! so the exec fails with `Text file busy` for exactly the child's
+//! fork-to-exec window. Inspecting the daemon's own `/proc/self/fd` after the
+//! rename cannot see the descriptor: it lives in the child's table.
+//!
+//! # The fix
+//!
+//! A process-wide `RwLock<()>`. Every child spawn holds the shared guard for
+//! the duration of the spawn call (the parent returns from `spawn` only after
+//! the child has exec'd or failed, so the shared guard brackets the entire
+//! fork-to-exec window). Materialization holds the exclusive guard from the
+//! moment the sibling temporary is opened for writing until the rename has
+//! published it, so no child can be forked while a materialization descriptor
+//! is open, and no descriptor can be opened while a child is between fork and
+//! exec.
+//!
+//! The critical sections contain no `.await`: the guard is a `std` lock held
+//! across a synchronous spawn or a synchronous copy + rename only.
+
+use std::sync::{PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+static SPAWN_MATERIALIZE_LOCK: RwLock<()> = RwLock::new(());
+
+/// Shared guard for one child spawn. Hold it for the spawn call only.
+pub(crate) fn spawn_shared() -> RwLockReadGuard<'static, ()> {
+    SPAWN_MATERIALIZE_LOCK
+        .read()
+        .unwrap_or_else(PoisonError::into_inner)
+}
+
+/// Exclusive guard for one materialization copy + publish. Hold it from before
+/// the sibling temporary is opened for writing until after the rename.
+pub(crate) fn materialize_exclusive() -> RwLockWriteGuard<'static, ()> {
+    SPAWN_MATERIALIZE_LOCK
+        .write()
+        .unwrap_or_else(PoisonError::into_inner)
+}


### PR DESCRIPTION
Fixes #1562. Investigation: zackees/soldr#3098.

## Failure

Cold `soldr cook` on soldr CI (run 33916129736 attempt 1, plus the two earlier recurrences on 1.13.20/1.13.21) fails a MISS build script with:

```
could not execute process `.../build/soldr-fetch-.../build-script-build` (never executed)
Caused by: Text file busy (os error 26)
```

## Mechanism

The staged-miss materialization (`materialize_independent_with_stats` -> `copy_output` -> unique sibling temp -> atomic rename) holds a write descriptor on the temp's inode while the same daemon process concurrently forks compiler children. A child forked inside that window inherits the descriptor until its own `execve` (`O_CLOEXEC` closes on exec, not fork). `rename(2)` keeps the inode, so once the daemon closes its descriptor and publishes the path, the inherited copy is still a writable descriptor on the *published* inode. Cargo hard-links `build-script-build` to that inode and execs it; `ETXTBSY` is evaluated per inode, so the exec fails for exactly the child's fork-to-exec window. The 2026-09-01 single-request probe could not see it: it looked in the daemon's `/proc/self/fd` after the rename, but the descriptor lives in the child's table.

## Fix

`daemon::spawn_exclusion`: a process-wide `std::sync::RwLock<()>`.

- Every daemon child spawn holds the **shared** guard for the spawn call only. `spawn` returns after the child has exec'd (or failed), so the guard brackets the whole fork-to-exec window. Both `running_process::spawn_tokio` calls in `daemon/process.rs` are wrapped; that is the choke point for `compile_exec`, `handle_compile_ephemeral`, `handle_compile_multi(_staged)`, `link_process` (link/archiver/deploy hook), `handle_exec::spawn_tool`, `system_includes` discovery, and the async identity probes. The sync `-vV`/`--version` probe in `compiler_hash::output_within` goes through `running_process::run_std_command_bounded`, which owns spawn and wait, so the shared guard brackets that bounded run (cold path, once per compiler identity, normally ~10 ms).
- `materialize_independent_with_stats` holds the **exclusive** guard from before the sibling temporary is opened until after the rename.

Neither critical section contains an `.await`. The comment on the sibling-temp + rename approach now states that the rename does not, on its own, make the output safe to execute.

Deliberately not guarded: `Command::new` sites under `#[cfg(test)]`, `test_support`, and `*_tests.rs` (test-only, not daemon runtime), and `running_process` daemon-spawn helpers that live in `zccache-cli-core` (the client process, not the daemon that materializes).

## Test

`daemon::server::persist::staged_store::materialize::tests::materialized_executable_runs_while_a_child_is_between_fork_and_exec` (Linux). Pauses a real materialization at the new `StagedHookPoint::MaterializeTemporaryOpen` with a write descriptor on the temp still open, spawns a child through the daemon spawn path whose `pre_exec` sleeps 500 ms, resumes, then execs the published output.

- With the exclusive guard removed: `FAIL ... Text file busy (os error 26)`
- With it: `PASS`

`soldr cargo nextest run -p zccache-daemon-core --features test-support,daemon-entry`: 844 passed, 30 skipped. `soldr cargo fmt --all -- --check` clean. `soldr cargo clippy --no-deps -p zccache-daemon-core --all-targets -D warnings` clean; the workspace-wide clippy run fails only on a pre-existing `double_must_use` in `crates/zccache-protocol/src/wire_prost/api.rs` (untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRsrtGd9JGqmFR8XSzGVAE
